### PR TITLE
Three small bugs in analysis and power optimization

### DIFF
--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -405,7 +405,11 @@ function Get-HealthScore {
 
     if ($AnalysisResults.TelemetryEnabled)       { $score -= 5 }
 
-    if ($AnalysisResults.CurrentPowerPlan -match "Balanced|Power saver") { $score -= 10 }
+    # Balanced is the recommended plan on laptops (battery life, thermals);
+    # only penalise non-performance plans on desktops.
+    if (-not $AnalysisResults.IsLaptop -and $AnalysisResults.CurrentPowerPlan -match "Balanced|Power saver") {
+        $score -= 10
+    }
 
     foreach ($d in $AnalysisResults.Disks) {
         if ($d.Health -eq "CRITICAL") { $score -= 15 }

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -227,10 +227,20 @@ function Get-SystemAnalysis {
         $bloatServices = $bloatServices | Where-Object { $_.Name -ne "SysMain" }
     }
 
-    # Context-aware: don't flag WSearch if Outlook is installed
-    $outlookInstalled = Test-Path "HKLM:\SOFTWARE\Microsoft\Office\*\Outlook" -ErrorAction SilentlyContinue
-    if (-not $outlookInstalled) {
-        $outlookInstalled = Test-Path "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Office\*\Outlook" -ErrorAction SilentlyContinue
+    # Context-aware: don't flag WSearch if Outlook is installed.
+    # Test-Path doesn't expand wildcards in registry providers, so we walk the
+    # version subkeys (15.0, 16.0, ...) and look for an Outlook child explicitly.
+    $outlookInstalled = $false
+    foreach ($officeRoot in @("HKLM:\SOFTWARE\Microsoft\Office", "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Office")) {
+        if (-not (Test-Path $officeRoot)) { continue }
+        $versionKeys = Get-ChildItem $officeRoot -ErrorAction SilentlyContinue
+        foreach ($vk in $versionKeys) {
+            if (Test-Path (Join-Path $vk.PSPath "Outlook")) {
+                $outlookInstalled = $true
+                break
+            }
+        }
+        if ($outlookInstalled) { break }
     }
     if ($outlookInstalled) {
         $bloatServices = $bloatServices | Where-Object { $_.Name -ne "WSearch" }

--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -43,12 +43,20 @@ function Invoke-PowerOptimization {
                 } elseif ($highGuid) {
                     powercfg /setactive $highGuid
                     Write-Fix "Activated High Performance power plan"
+                } else {
+                    Write-Skip "No Ultimate or High Performance power scheme available on this system"
                 }
             }
         }
 
-        Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" "PowerThrottlingOff" 1
-        Write-Fix "Disabled power throttling"
+        # PowerThrottling key was added in 1903 (build 18362); writing it on
+        # earlier builds creates a key Windows ignores while we report success.
+        if ([int]$Analysis.OSBuild -ge 18362) {
+            Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" "PowerThrottlingOff" 1
+            Write-Fix "Disabled power throttling"
+        } else {
+            Write-Skip "Power throttling tweak skipped (requires Windows 10 1903 or newer)"
+        }
     } catch {
         Write-Skip "Power plan optimization encountered errors"
         Log "[ERROR] Power plan: $_"

--- a/tests/Analysis.Tests.ps1
+++ b/tests/Analysis.Tests.ps1
@@ -154,8 +154,9 @@ Describe "Health Score Calculation" {
         $score | Should -Be 85
     }
 
-    It "Should deduct points for Balanced power plan" {
+    It "Should deduct points for Balanced power plan on a desktop" {
         $results = @{
+            IsLaptop          = $false
             RAMUsedPct        = 30
             StartupItems      = @()
             TempSizeMB        = 10
@@ -167,6 +168,38 @@ Describe "Health Score Calculation" {
         }
         $score = Get-HealthScore -AnalysisResults $results
         $score | Should -Be 90
+    }
+
+    It "Should not deduct points for Balanced power plan on a laptop" {
+        $results = @{
+            IsLaptop          = $true
+            RAMUsedPct        = 30
+            StartupItems      = @()
+            TempSizeMB        = 10
+            ServicesToDisable  = @()
+            TelemetryEnabled  = $false
+            CurrentPowerPlan   = "Balanced"
+            Disks             = @(@{ Health = "HEALTHY" })
+            VisualEffects      = "Performance"
+        }
+        $score = Get-HealthScore -AnalysisResults $results
+        $score | Should -Be 100
+    }
+
+    It "Should not deduct points for Power saver on a laptop" {
+        $results = @{
+            IsLaptop          = $true
+            RAMUsedPct        = 30
+            StartupItems      = @()
+            TempSizeMB        = 10
+            ServicesToDisable  = @()
+            TelemetryEnabled  = $false
+            CurrentPowerPlan   = "Power saver"
+            Disks             = @(@{ Health = "HEALTHY" })
+            VisualEffects      = "Performance"
+        }
+        $score = Get-HealthScore -AnalysisResults $results
+        $score | Should -Be 100
     }
 
     It "Should accumulate multiple deductions" {


### PR DESCRIPTION
Picking off four well-scoped bug reports from the open issues list.
Nothing here touches the higher-risk paths (cleanup recursion, undo
file path, run.ps1 integrity), which deserve their own focused PRs.

## Changes

- **#33 — PowerThrottling write is a no-op below build 18362.**
  Gated on `[int]$Analysis.OSBuild -ge 18362`, matching the existing
  19041 guard for hardware GPU scheduling.
- **#34 — `powercfg /setactive` ran against `$null` on stripped
  images.** Added an explicit Skip when neither Ultimate nor High
  Performance is available.
- **#15 — Health score penalised Balanced on laptops where it's
  the recommended plan.** `Get-HealthScore` now reads `IsLaptop`
  and only deducts on desktops. New Pester cases cover both
  Balanced and Power saver on the laptop branch.
- **#26 — Outlook detection used `Test-Path` with a registry
  wildcard, which never matched.** Now walks the Office key
  explicitly across both native and WOW6432Node hives, so WSearch
  is correctly preserved when Outlook is installed.

## Tests

- `Invoke-ScriptAnalyzer` clean across all `.ps1`/`.psm1` (same
  exclusions as CI).
- `tests/Analysis.Tests.ps1` — 15 pass (12 original + 1 renamed +
  2 new laptop cases).
- The two `UndoManager.Tests.ps1` failures showing up locally are
  pre-existing and unrelated to this change; the GitHub Actions
  runner has been green on these tests since #58a6f88. Tracking
  separately.

## Follow-ups

- #29 should be closed as already-fixed; `MenuShowDelay` is already
  written with explicit `"String"` type at `Explorer.psm1:18`.
- The two local UndoManager failures look like a Pester / PowerShell
  version difference. Worth investigating once I can repro on the CI
  runner image.

Closes #15, #26, #33, #34.