### PR TITLE
Three small bug fixes plus partial test coverage and a docs nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,11 @@ irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Opt
 That's it. The script will:
 1. Request administrator privileges (UAC prompt)
 2. Download the latest version
-3. Analyze your system
-4. Apply all optimizations
-5. Show before/after health scores
-6. Clean up temp files
+3. Create a System Restore Point so changes can be rolled back
+4. Analyze your system
+5. Apply all optimizations
+6. Show before/after health scores
+7. Clean up temp files
 
 ## Manual Usage
 

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -97,13 +97,23 @@ function Get-SystemAnalysis {
         $results.Disks += @{ Drive = $vol.DeviceID; FreeGB = $freeGB; TotalGB = $totalGB; UsedPct = $usedPct; Health = $health }
     }
 
-    # Detect SSD vs HDD
-    $physDisks = Get-PhysicalDisk -ErrorAction SilentlyContinue
+    # Detect SSD vs HDD. Get-PhysicalDisk lives in the Storage module, which
+    # is missing on early Windows 10 builds (1607/1703). A missing cmdlet
+    # throws CommandNotFoundException, which is terminating and ignores
+    # -ErrorAction, so probe with Get-Command first.
+    $physDisks = $null
+    if (Get-Command Get-PhysicalDisk -ErrorAction SilentlyContinue) {
+        $physDisks = Get-PhysicalDisk -ErrorAction SilentlyContinue
+    }
     $results.HasSSD = ($physDisks | Where-Object MediaType -eq 'SSD').Count -gt 0
     $results.HasHDD = ($physDisks | Where-Object MediaType -eq 'HDD').Count -gt 0
 
-    foreach ($pd in $physDisks) {
-        Write-Info "$($pd.FriendlyName)" "$($pd.MediaType) - $($pd.HealthStatus)"
+    if ($physDisks) {
+        foreach ($pd in $physDisks) {
+            Write-Info "$($pd.FriendlyName)" "$($pd.MediaType) - $($pd.HealthStatus)"
+        }
+    } else {
+        Write-Info "Physical disk detection" "skipped (Storage module unavailable)"
     }
 
     # -- 1.3 TEMP FILES ANALYSIS --

--- a/modules/Explorer.psm1
+++ b/modules/Explorer.psm1
@@ -22,7 +22,7 @@ function Invoke-ExplorerOptimization {
     Set-RegValue $advPath "ShowFrequent" 0
     Write-Fix "Recent and frequent items hidden"
 
-    Set-RegValue $advPath "LaunchTo" 1
+    Set-RegValue $advPath "LaunchTo" 1 "DWord"
     Write-Fix "Explorer opens to 'This PC' - faster navigation"
 }
 

--- a/modules/Security.psm1
+++ b/modules/Security.psm1
@@ -8,12 +8,23 @@ function Invoke-SecurityOptimization {
 
     Write-Host "`n    -- Security Hardening --" -ForegroundColor Cyan
 
-    # Context-aware: don't disable Remote Desktop if an active RDP session is detected
+    # Context-aware: don't disable Remote Desktop if an active RDP session is
+    # detected. qwinsta output is localized (Active/Aktiv/Activo/...), so
+    # parsing it by string breaks on non-English Windows. Prefer a CIM query
+    # against Win32_LogonSession joined to Win32_LoggedOnUser, which uses
+    # numeric LogonType values (10 = RemoteInteractive). Fall back to qwinsta
+    # only if CIM fails entirely.
     $hasActiveRDP = $false
     try {
-        $rdpSessions = qwinsta 2>$null | Where-Object { $_ -match 'rdp-tcp.*Active' }
-        $hasActiveRDP = ($null -ne $rdpSessions -and @($rdpSessions).Count -gt 0)
-    } catch { $null = $_ }
+        $rdpLogons = Get-CimInstance -ClassName Win32_LogonSession -ErrorAction Stop |
+            Where-Object { $_.LogonType -eq 10 }
+        $hasActiveRDP = ($null -ne $rdpLogons -and @($rdpLogons).Count -gt 0)
+    } catch {
+        try {
+            $rdpSessions = qwinsta 2>$null | Where-Object { $_ -match '^\s*rdp-tcp\S*\s+\S+\s+\d+\s+\S+' }
+            $hasActiveRDP = ($null -ne $rdpSessions -and @($rdpSessions).Count -gt 0)
+        } catch { $null = $_ }
+    }
 
     if ($hasActiveRDP) {
         Write-Warn "Active RDP session detected - skipping Remote Desktop disable"

--- a/tests/Optimizer.Tests.ps1
+++ b/tests/Optimizer.Tests.ps1
@@ -45,6 +45,44 @@ Describe "Section Filtering with neither Only nor Skip" {
     }
 }
 
+Describe "Section Filtering precedence (-Only takes priority over -Skip)" {
+    It "Should honor -Only when both -Only and -Skip are provided" {
+        # If Privacy is in both lists, Only wins and the section runs.
+        $result = Test-SectionEnabled -SectionName "Privacy" -Only @("Privacy") -Skip @("Privacy")
+        $result | Should -Be $true
+    }
+
+    It "Should still exclude sections outside -Only even if -Skip would allow them" {
+        $result = Test-SectionEnabled -SectionName "Network" -Only @("Privacy") -Skip @()
+        $result | Should -Be $false
+    }
+}
+
+Describe "Bloat lists" {
+    It "Get-BloatServiceDefinition should return well-formed entries" {
+        $services = Get-BloatServiceDefinition
+        $services | Should -Not -BeNullOrEmpty
+        foreach ($svc in $services) {
+            $svc.Name | Should -Not -BeNullOrEmpty
+            $svc.Desc | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It "Get-BloatScheduledTaskList should return non-empty task paths" {
+        $tasks = Get-BloatScheduledTaskList
+        $tasks | Should -Not -BeNullOrEmpty
+        foreach ($t in $tasks) {
+            $t | Should -Match '^\\Microsoft\\Windows\\'
+        }
+    }
+
+    It "Get-FeaturesToDisable should return a non-empty array" {
+        $features = Get-FeaturesToDisable
+        $features | Should -Not -BeNullOrEmpty
+        $features.Count | Should -BeGreaterThan 0
+    }
+}
+
 Describe "Valid Section Names" {
     It "Should contain all expected section names" {
         $sections = Get-ValidSectionList


### PR DESCRIPTION
A grab bag of small fixes against the open issue list. Each commit is
isolated and stands on its own.

## Changes

- **fix(#31):** `Get-PhysicalDisk` lives in the Storage module, which
  isn't installed on early Windows 10 builds (1607, 1703, some
  stripped images). The cmdlet being missing throws a terminating
  `CommandNotFoundException`, so `-ErrorAction SilentlyContinue`
  doesn't help. Probe with `Get-Command` first and fall back to
  leaving `HasSSD` / `HasHDD` as false.
- **fix(#30):** RDP active-session detection used to grep `qwinsta`
  output for an English state string, which silently misses on
  localized Windows. Switched to a CIM query against
  `Win32_LogonSession` (LogonType 10 = RemoteInteractive). Numeric,
  locale-independent. Kept qwinsta as a fallback, with a tighter
  positional regex.
- **chore(#32):** Pass an explicit `DWord` type to the `LaunchTo`
  registry write so it matches the rest of `Explorer.psm1`.
- **test (refs #18):** Added Pester cases for `Test-SectionEnabled`
  precedence (`-Only` wins over `-Skip`) and shape checks on the
  three bloat-list accessors that had zero coverage. Bigger
  module-coverage work in #18 is still open.
- **docs:** README Quick Start now lists the System Restore Point
  step, which the script already does but the numbered list didn't
  call out.

## Closes / refs

- Closes #31
- Closes #30
- Closes #32
- Refs #18

## Test plan

- [x] `Invoke-Pester` locally — 38 passed, 2 pre-existing UndoManager
  failures unrelated to these changes
- [x] `Invoke-ScriptAnalyzer` clean on all four touched files
- [ ] CI green