### PR TITLE
Four small bug fixes around audio scheduling, COM cleanup, SSD prefetch, and a docs nit

### DIFF
--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -48,6 +48,9 @@ function Get-SystemAnalysis {
     }
 
     $results.IsLaptop    = ($null -ne $bat) -or ($cs.PCSystemType -eq 2)
+    # TotalVisibleMemorySize / FreePhysicalMemory are reported in KB by
+    # Win32_OperatingSystem. Dividing by the PowerShell constant 1MB
+    # (= 1,048,576) does KB -> GB in one step: KB / (KB-per-GB).
     $results.TotalRAMGB  = [math]::Round($os.TotalVisibleMemorySize / 1MB, 1)
     $results.FreeRAMGB   = [math]::Round($os.FreePhysicalMemory / 1MB, 1)
     $results.RAMUsedPct  = [math]::Round((1 - $os.FreePhysicalMemory / $os.TotalVisibleMemorySize) * 100, 1)

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -146,13 +146,22 @@ function Get-SystemAnalysis {
     }
     $results.TempSizeMB = [math]::Round($results.TempSizeMB, 1)
 
-    # Recycle Bin
+    # Recycle Bin. Shell.Application is a COM object; if we don't release
+    # it explicitly the COM server stays loaded for the life of the
+    # process, which leaks a handle on every analysis run.
     $rbCount = 0
+    $shell = $null
     try {
-        $recycleBin = (New-Object -ComObject Shell.Application).NameSpace(0xA)
-        $rbCount = $recycleBin.Items().Count
+        $shell = New-Object -ComObject Shell.Application
+        $recycleBin = $shell.NameSpace(0xA)
+        if ($recycleBin) { $rbCount = $recycleBin.Items().Count }
     } catch {
         Log "[ERROR] Could not query Recycle Bin: $_"
+    } finally {
+        if ($shell) {
+            [void][System.Runtime.InteropServices.Marshal]::ReleaseComObject($shell)
+            $shell = $null
+        }
     }
 
     if ($results.TempSizeMB -gt 500) {

--- a/modules/Network.psm1
+++ b/modules/Network.psm1
@@ -16,8 +16,12 @@ function Invoke-NetworkOptimization {
     Write-Fix "Nagle's algorithm disabled (lower latency)"
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "NetworkThrottlingIndex" 0xFFFFFFFF
-    Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "SystemResponsiveness" 0
-    Write-Fix "Network throttling disabled"
+    # SystemResponsiveness is the % CPU MMCSS reserves for background system
+    # tasks. 0 starves audio scheduling and timer interrupts; Microsoft's
+    # guidance is 10-20%. 10 keeps gaming/network priority high without
+    # crippling background work.
+    Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "SystemResponsiveness" 10
+    Write-Fix "Network throttling disabled (SystemResponsiveness=10)"
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxCacheTtl" 86400
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxNegativeCacheTtl" 5

--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -143,9 +143,18 @@ function Invoke-SSDOptimization {
 
     Write-Host "`n    -- SSD Optimization --" -ForegroundColor Cyan
 
-    Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnablePrefetcher" 0
-    Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnableSuperfetch" 0
-    Write-Fix "Prefetch/Superfetch disabled (SSD doesn't need it)"
+    # Windows 10 1809 (build 17763) and newer detect SSDs and adapt
+    # Prefetch/Superfetch behavior automatically. Forcing them off there
+    # disables a useful cache for any HDD also present in the system and
+    # buys nothing on the SSD. Only apply the disable on older builds
+    # where the OS still treats every drive the same.
+    if ([int]$Analysis.OSBuild -lt 17763) {
+        Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnablePrefetcher" 0
+        Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnableSuperfetch" 0
+        Write-Fix "Prefetch/Superfetch disabled (legacy build, SSD doesn't need it)"
+    } else {
+        Write-Skip "Prefetch/Superfetch left to Windows (1809+ adapts per drive type)"
+    }
 
     if ($DryRun) {
         Write-Dry "Would disable last access timestamps"


### PR DESCRIPTION
Another small batch, same pattern as the last few PRs: pick issues
with one clear edit and minimal blast radius, leave the high-risk
items (cleanup recursion, run.ps1 integrity, undo file design,
registry path validation) for their own focused work.

## Changes

- **fix(network): SystemResponsiveness 0 -> 10.** Setting MMCSS to 0
  starves background system tasks and causes audio glitches and
  missed timer interrupts; Microsoft recommends 10-20%. Picked 10 to
  keep gaming/network priority high without crippling background
  work. (Closes #25)

- **fix(analysis): release Shell.Application COM object.** The
  Recycle Bin probe was newing up a COM object and never releasing
  it, leaking a handle and keeping the COM server loaded for the
  rest of the process. Wrapped in try/finally with
  `Marshal::ReleaseComObject`. (Closes #24)

- **fix(performance): gate Prefetch/Superfetch disable to legacy
  builds.** SSD optimization was unconditionally writing
  `EnablePrefetcher = 0` and `EnableSuperfetch = 0`. On Windows 10
  1809+ (build 17763) the OS adapts per drive automatically, so the
  disable doesn't help the SSD and actively hurts any HDD installed
  alongside it. Now gated on `OSBuild < 17763`, matching the
  existing pattern for `PowerThrottling` and `HwSchMode`.
  (Closes #21)

- **docs(analysis): explain the KB-to-GB conversion.** The RAM math
  divides `TotalVisibleMemorySize` (KB) by the constant `1MB` to land
  on GB. Correct, but the unit names look like a category mistake on
  first read. Added a short comment so the next reader doesn't have
  to puzzle it out. (Closes #16)

## Issue housekeeping

- Closes #34 - "Missing guard around power-scheme GUIDs" was
  actually fixed in PR #35, but the closing keyword was in the
  squash-commit body and GitHub didn't auto-close. Closing it here.

## Skipped

- #28 (recursive cleanup) - still too risky for a one-liner.
- #11 / #10 (run.ps1 integrity) - supply-chain change, separate PR.
- #2 (undo doesn't capture non-registry changes) - design work.
- #13 (registry path validation) - touches Set-RegValue, hits every
  module.

## Test plan

- [x] PSScriptAnalyzer clean across the repo with the project's
      ExcludeRule set
- [x] Pester suite passes locally on the modified files (one
      pre-existing failure in `UndoManager.Tests.ps1` around
      `Should -Throw` semantics on a non-existent file path; unrelated
      to this PR, present on main, CI is green there)
- [ ] CI on the PR