### PR TITLE
Five small bug fixes around cleanup, network, printing, run.ps1, and startup re-check

### DIFF
--- a/Ultimate-Windows-System-Optimizer.ps1
+++ b/Ultimate-Windows-System-Optimizer.ps1
@@ -259,7 +259,7 @@ Write-Section "PHASE 3: OPTIMIZATION COMPLETE"
 # Re-analyze to get actual post-optimization score
 $postResults = @{
     RAMUsedPct        = $analysisResults.RAMUsedPct
-    StartupItems      = $analysisResults.StartupItems
+    StartupItems      = Get-StartupItem
     TempSizeMB        = 0  # temp files cleaned
     ServicesToDisable  = @()
     TelemetryEnabled  = $false

--- a/Ultimate-Windows-System-Optimizer.ps1
+++ b/Ultimate-Windows-System-Optimizer.ps1
@@ -259,7 +259,7 @@ Write-Section "PHASE 3: OPTIMIZATION COMPLETE"
 # Re-analyze to get actual post-optimization score
 $postResults = @{
     RAMUsedPct        = $analysisResults.RAMUsedPct
-    StartupItems      = Get-StartupItem
+    StartupItems      = @(Get-StartupItem)
     TempSizeMB        = 0  # temp files cleaned
     ServicesToDisable  = @()
     TelemetryEnabled  = $false

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -42,7 +42,9 @@ function Get-StartupItem {
         Log "[ERROR] Could not enumerate scheduled tasks: $_"
     }
 
-    return ,$items
+    # Stream items so callers see a flat array via @(Get-StartupItem)
+    # rather than a 1-element wrapper that the pipeline then unwraps weirdly.
+    return $items
 }
 
 function Get-SystemAnalysis {
@@ -233,7 +235,7 @@ function Get-SystemAnalysis {
     # -- 1.4 STARTUP PROGRAMS --
     Write-Host "`n    -- Startup Programs --" -ForegroundColor Cyan
 
-    $results.StartupItems = Get-StartupItem
+    $results.StartupItems = @(Get-StartupItem)
 
     $startupCount = $results.StartupItems.Count
     if ($startupCount -gt 15) {

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -1,5 +1,50 @@
 # Analysis.psm1 - Phase 1: System analysis and health scoring
 
+function Get-StartupItem {
+    # Returns the union of registry Run/RunOnce entries, the user's
+    # Startup folder shortcuts, and scheduled tasks with a logon
+    # trigger. Each item is a hashtable with Name/Source/Path.
+    $items = @()
+
+    $regPaths = @(
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run",
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run",
+        "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce",
+        "HKLM:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
+    )
+    foreach ($rp in $regPaths) {
+        if (Test-Path $rp) {
+            $props = Get-ItemProperty $rp -ErrorAction SilentlyContinue
+            if ($props) {
+                $props.PSObject.Properties | Where-Object { $_.Name -notlike 'PS*' } | ForEach-Object {
+                    $items += @{ Name = $_.Name; Source = "Registry"; Path = $_.Value }
+                }
+            }
+        }
+    }
+
+    $startupFolder = [System.IO.Path]::Combine($env:APPDATA, 'Microsoft\Windows\Start Menu\Programs\Startup')
+    if (Test-Path $startupFolder) {
+        Get-ChildItem $startupFolder -File -ErrorAction SilentlyContinue | ForEach-Object {
+            $items += @{ Name = $_.BaseName; Source = "StartupFolder"; Path = $_.FullName }
+        }
+    }
+
+    try {
+        $logonTasks = Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
+            $_.State -ne 'Disabled' -and
+            ($_.Triggers | Where-Object { $_.CimClass.CimClassName -eq 'MSFT_TaskLogonTrigger' })
+        }
+        foreach ($lt in $logonTasks) {
+            $items += @{ Name = $lt.TaskName; Source = "ScheduledTask"; Path = $lt.TaskPath }
+        }
+    } catch {
+        Log "[ERROR] Could not enumerate scheduled tasks: $_"
+    }
+
+    return ,$items
+}
+
 function Get-SystemAnalysis {
     Write-Section "PHASE 1: DEEP SYSTEM ANALYSIS"
 
@@ -188,43 +233,7 @@ function Get-SystemAnalysis {
     # -- 1.4 STARTUP PROGRAMS --
     Write-Host "`n    -- Startup Programs --" -ForegroundColor Cyan
 
-    $results.StartupItems = @()
-
-    $regPaths = @(
-        "HKCU:\Software\Microsoft\Windows\CurrentVersion\Run",
-        "HKLM:\Software\Microsoft\Windows\CurrentVersion\Run",
-        "HKCU:\Software\Microsoft\Windows\CurrentVersion\RunOnce",
-        "HKLM:\Software\Microsoft\Windows\CurrentVersion\RunOnce"
-    )
-    foreach ($rp in $regPaths) {
-        if (Test-Path $rp) {
-            $props = Get-ItemProperty $rp -ErrorAction SilentlyContinue
-            if ($props) {
-                $props.PSObject.Properties | Where-Object { $_.Name -notlike 'PS*' } | ForEach-Object {
-                    $results.StartupItems += @{ Name = $_.Name; Source = "Registry"; Path = $_.Value }
-                }
-            }
-        }
-    }
-
-    $startupFolder = [System.IO.Path]::Combine($env:APPDATA, 'Microsoft\Windows\Start Menu\Programs\Startup')
-    if (Test-Path $startupFolder) {
-        Get-ChildItem $startupFolder -File -ErrorAction SilentlyContinue | ForEach-Object {
-            $results.StartupItems += @{ Name = $_.BaseName; Source = "StartupFolder"; Path = $_.FullName }
-        }
-    }
-
-    try {
-        $logonTasks = Get-ScheduledTask -ErrorAction SilentlyContinue | Where-Object {
-            $_.State -ne 'Disabled' -and
-            ($_.Triggers | Where-Object { $_.CimClass.CimClassName -eq 'MSFT_TaskLogonTrigger' })
-        }
-        foreach ($lt in $logonTasks) {
-            $results.StartupItems += @{ Name = $lt.TaskName; Source = "ScheduledTask"; Path = $lt.TaskPath }
-        }
-    } catch {
-        Log "[ERROR] Could not enumerate scheduled tasks: $_"
-    }
+    $results.StartupItems = Get-StartupItem
 
     $startupCount = $results.StartupItems.Count
     if ($startupCount -gt 15) {
@@ -453,4 +462,4 @@ function Get-HealthScore {
     return [math]::Max(0, [math]::Min(100, $score))
 }
 
-Export-ModuleMember -Function Get-SystemAnalysis, Get-HealthScore
+Export-ModuleMember -Function Get-SystemAnalysis, Get-HealthScore, Get-StartupItem

--- a/modules/Cleanup.psm1
+++ b/modules/Cleanup.psm1
@@ -78,7 +78,15 @@ function Invoke-CleanupOptimization {
             }
         }
         try {
-            Start-Process -FilePath "cleanmgr.exe" -ArgumentList "/sagerun:100" -WindowStyle Hidden -ErrorAction SilentlyContinue
+            # /sagerun:100 must complete before downstream phases reanalyze
+            # disk state. Cap the wait at 10 minutes so a stuck cleanmgr
+            # doesn't hang the whole run; on locked-down installs it has.
+            $proc = Start-Process -FilePath "cleanmgr.exe" -ArgumentList "/sagerun:100" -WindowStyle Hidden -PassThru -ErrorAction Stop
+            if (-not $proc.WaitForExit(600000)) {
+                try { $proc.Kill() } catch { $null = $_ }
+                Write-Skip "Disk Cleanup timed out after 10 minutes"
+                Log "[WARN] cleanmgr.exe killed after 10-minute timeout"
+            }
         } catch {
             Log "[ERROR] Disk Cleanup utility failed to start: $_"
         }

--- a/modules/Network.psm1
+++ b/modules/Network.psm1
@@ -8,12 +8,39 @@ function Invoke-NetworkOptimization {
 
     Write-Host "`n    -- Network Optimization --" -ForegroundColor Cyan
 
-    $interfaces = Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces" -ErrorAction SilentlyContinue
-    foreach ($iface in $interfaces) {
-        Set-RegValue $iface.PSPath "TcpNoDelay" 1
-        Set-RegValue $iface.PSPath "TcpAckFrequency" 1
+    # Build the set of NetCfgInstanceId GUIDs that belong to physical,
+    # non-virtual adapters. Without this filter we also write the keys
+    # under loopback, Hyper-V switches, and VPN adapters, where toggling
+    # Nagle is at best pointless and at worst harmful (loopback latency
+    # regressions, broken VPN MTU behavior).
+    $physicalGuids = @{}
+    try {
+        Get-NetAdapter -Physical -ErrorAction Stop |
+            Where-Object { $_.Status -ne 'Disabled' -and $_.Virtual -ne $true } |
+            ForEach-Object {
+                if ($_.InterfaceGuid) { $physicalGuids[$_.InterfaceGuid.ToLower()] = $true }
+            }
+    } catch {
+        Log "[WARN] Get-NetAdapter unavailable; skipping Nagle tweaks: $_"
     }
-    Write-Fix "Nagle's algorithm disabled (lower latency)"
+
+    $applied = 0
+    if ($physicalGuids.Count -gt 0) {
+        $interfaces = Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces" -ErrorAction SilentlyContinue
+        foreach ($iface in $interfaces) {
+            $guid = ($iface.PSChildName).ToLower()
+            if (-not $physicalGuids.ContainsKey($guid)) { continue }
+            Set-RegValue $iface.PSPath "TcpNoDelay" 1
+            Set-RegValue $iface.PSPath "TcpAckFrequency" 1
+            $applied++
+        }
+    }
+
+    if ($applied -gt 0) {
+        Write-Fix "Nagle's algorithm disabled on $applied physical adapter(s)"
+    } else {
+        Write-Skip "No eligible physical adapters; skipped Nagle tuning"
+    }
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "NetworkThrottlingIndex" 0xFFFFFFFF
     # SystemResponsiveness is the % CPU MMCSS reserves for background system

--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -334,17 +334,24 @@ function Invoke-FeaturesOptimization {
 
     $featuresToDisable = Get-FeaturesToDisable
 
-    # Context-aware: don't disable printing features if printers are installed
-    $hasPrinters = $false
+    # Context-aware: don't disable printing features if printers are installed.
+    # Microsoft Print to PDF and the XPS Document Writer also depend on
+    # Printing-Foundation-Features, so removing the feature kills the
+    # built-in PDF print pipeline even on machines with no physical printer.
+    $hasPhysicalPrinters = $false
+    $hasVirtualPrinters = $false
     try {
-        $printers = Get-Printer -ErrorAction SilentlyContinue |
-            Where-Object { $_.Name -notmatch 'Microsoft|Fax|OneNote|PDF|XPS' }
-        $hasPrinters = ($null -ne $printers -and @($printers).Count -gt 0)
+        $allPrinters = @(Get-Printer -ErrorAction SilentlyContinue)
+        $hasPhysicalPrinters = @($allPrinters | Where-Object { $_.Name -notmatch 'Microsoft|Fax|OneNote|PDF|XPS' }).Count -gt 0
+        $hasVirtualPrinters  = @($allPrinters | Where-Object { $_.Name -match 'Print to PDF|XPS Document Writer' }).Count -gt 0
     } catch { $null = $_ }
 
-    if ($hasPrinters) {
+    if ($hasPhysicalPrinters) {
         $featuresToDisable = $featuresToDisable | Where-Object { $_ -ne "Printing-Foundation-Features" }
         Write-Info "Printers detected" "Keeping printing features"
+    } elseif ($hasVirtualPrinters) {
+        $featuresToDisable = $featuresToDisable | Where-Object { $_ -ne "Printing-Foundation-Features" }
+        Write-Info "Print to PDF / XPS detected" "Keeping printing features"
     }
 
     foreach ($feat in $featuresToDisable) {

--- a/run.ps1
+++ b/run.ps1
@@ -3,17 +3,32 @@
     One-click installer and runner for Ultimate Windows System Optimizer.
     Downloads, extracts, and runs the optimizer automatically with admin privileges.
 
+.PARAMETER Auto
+    Skip every confirmation prompt in the optimizer (passes -Force to the
+    main script). Off by default; opt in only for unattended runs.
+
 .DESCRIPTION
     Usage (paste into PowerShell):
         irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex
+
+    Hands-off run (no prompts):
+        $env:UWSO_AUTO = '1'; irm .../run.ps1 | iex
 #>
+
+param(
+    [switch]$Auto
+)
+
+# Allow opt-in via env var too, since piping into iex strips parameters
+if ($env:UWSO_AUTO -eq '1') { $Auto = $true }
 
 # Self-elevate to admin if not already
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 if (-not $isAdmin) {
     Write-Host "`n  Requesting administrator privileges..." -ForegroundColor Yellow
+    $autoEnv = if ($Auto) { "`$env:UWSO_AUTO = '1'; " } else { "" }
     $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(
-        "Set-ExecutionPolicy Bypass -Scope Process -Force; irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex"
+        "Set-ExecutionPolicy Bypass -Scope Process -Force; ${autoEnv}irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex"
     ))
     Start-Process powershell.exe -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded" -Verb RunAs
     return
@@ -50,7 +65,9 @@ try {
     Write-Host ""
 
     $mainScript = Join-Path $scriptDir.FullName "Ultimate-Windows-System-Optimizer.ps1"
-    powershell.exe -NoProfile -ExecutionPolicy Bypass -File $mainScript -Force
+    $mainArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $mainScript)
+    if ($Auto) { $mainArgs += "-Force" }
+    powershell.exe @mainArgs
 
 } catch {
     Write-Host ""

--- a/tests/Analysis.Tests.ps1
+++ b/tests/Analysis.Tests.ps1
@@ -237,3 +237,29 @@ Describe "Health Score Calculation" {
         $score | Should -BeGreaterOrEqual 0
     }
 }
+
+Describe "Get-StartupItem" {
+    It "Should return an array (possibly empty)" {
+        $items = Get-StartupItem
+        # Force-wrap so a 0- or 1-element collection still tests as array.
+        @($items) | Should -BeOfType [System.Object]
+        @($items).GetType().IsArray -or @($items) -is [System.Collections.IEnumerable] | Should -Be $true
+    }
+
+    It "Each item should expose Name, Source, and Path keys" {
+        $items = @(Get-StartupItem)
+        foreach ($it in $items) {
+            $it.ContainsKey('Name')   | Should -Be $true
+            $it.ContainsKey('Source') | Should -Be $true
+            $it.ContainsKey('Path')   | Should -Be $true
+        }
+    }
+
+    It "Source values should be one of the known origins" {
+        $items = @(Get-StartupItem)
+        $valid = @('Registry', 'StartupFolder', 'ScheduledTask')
+        foreach ($it in $items) {
+            $valid | Should -Contain $it.Source
+        }
+    }
+}

--- a/tests/Analysis.Tests.ps1
+++ b/tests/Analysis.Tests.ps1
@@ -239,16 +239,15 @@ Describe "Health Score Calculation" {
 }
 
 Describe "Get-StartupItem" {
-    It "Should return an array (possibly empty)" {
-        $items = Get-StartupItem
-        # Force-wrap so a 0- or 1-element collection still tests as array.
-        @($items) | Should -BeOfType [System.Object]
-        @($items).GetType().IsArray -or @($items) -is [System.Collections.IEnumerable] | Should -Be $true
+    It "Should be invocable and return enumerable output" {
+        $items = @(Get-StartupItem)
+        $items.GetType().IsArray | Should -Be $true
     }
 
     It "Each item should expose Name, Source, and Path keys" {
         $items = @(Get-StartupItem)
         foreach ($it in $items) {
+            $it -is [hashtable]       | Should -Be $true
             $it.ContainsKey('Name')   | Should -Be $true
             $it.ContainsKey('Source') | Should -Be $true
             $it.ContainsKey('Path')   | Should -Be $true


### PR DESCRIPTION
## What's in here

Five real issues from the tracker, each scoped to one file (mostly), plus
a small Pester case for the helper I pulled out.

- **#4** - `cleanmgr.exe /sagerun:100` was launched without `-Wait`, so the
  "Total space recovered" line printed before the utility had done anything
  and downstream phases reanalyzed disk state mid-cleanup. Now uses
  `-PassThru` + `WaitForExit(600000)` so a hung cleanmgr (seen on
  locked-down installs) doesn't block the entire run forever.

- **#9** - The network optimization phase walked every key under
  `Tcpip\Parameters\Interfaces` and wrote `TcpNoDelay` /
  `TcpAckFrequency` to all of them, including loopback, Hyper-V virtual
  switches, and VPN adapters. Now resolves the registry key GUIDs
  against `Get-NetAdapter -Physical` and writes only to physical,
  non-virtual interfaces. Falls back cleanly on Server Core where
  `Get-NetAdapter` isn't available.

- **#19** - `Performance.psm1` already preserved
  Printing-Foundation-Features when a physical printer was detected,
  but Microsoft Print to PDF and the XPS Document Writer also depend
  on that feature. Removing it broke the built-in PDF print pipeline
  on every machine without a physical printer. Now keeps the feature
  whenever either virtual printer is enabled.

- **#1** - `run.ps1` launched the main script with `-Force`,
  unconditionally. That's hostile for a script that touches services,
  registry, scheduled tasks, and BCD. Dropped the unconditional flag,
  added an opt-in `-Auto` switch (with a `UWSO_AUTO` env-var fallback
  for the iex pipeline case) for users who want unattended runs.

- **#17** - The post-optimization score copied
  `$analysisResults.StartupItems` straight into `$postResults`, so
  startup entries trimmed during the run were still counted in the
  after-score. Pulled the enumeration into a new `Get-StartupItem`
  helper in `Analysis.psm1` and call it from both
  `Get-SystemAnalysis` and the main script's post-results hashtable.

## Tests

- Three Pester cases for `Get-StartupItem`: returns an array, every
  entry has Name/Source/Path keys, Source values stay within the known
  origins.
- Full suite: 41 pass / 2 fail. The two failures are pre-existing
  `UndoManager.Tests.ps1` cases that also fail on `main` and don't
  fail CI (Pester 5 doesn't propagate result counts to the exit code
  in this workflow).
- PSScriptAnalyzer: clean (Warning + Error severities,
  excluding `PSAvoidUsingWriteHost` and `PSUseBOMForUnicodeEncodedFile`
  per existing config).

## Follow-ups (intentionally not in this PR)

- #28 (recursive cleanup) needs more careful design.
- #11 / #10 (run.ps1 integrity) is a supply-chain rework deserving
  its own PR.
- #2 (undo doesn't capture non-registry changes) is a design change.
- #13 (registry path validation in `Set-RegValue`) touches every module.
- The two stale UndoManager test failures could use a follow-up to
  fix or re-shape the assertions.

Closes #1
Closes #4
Closes #9
Closes #17
Closes #19