### PR TITLE
Stop assuming Desktop and C: in three small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ If you prefer to clone and run manually:
 .\Ultimate-Windows-System-Optimizer.ps1 -Skip "Security"
 
 # Restore from undo file:
-.\Ultimate-Windows-System-Optimizer.ps1 -Undo "C:\Users\you\Desktop\undo_20260329_120000.json"
+.\Ultimate-Windows-System-Optimizer.ps1 -Undo "$env:LOCALAPPDATA\UWSO\undo_20260329_120000.json"
 ```
 
 ## Modules
@@ -147,7 +147,7 @@ Each optimization module exports a single `Invoke-*Optimization` function. The a
 
 ## Output
 
-A log file is saved to the desktop:
+A log file is saved under `%LOCALAPPDATA%\UWSO\` (with fallback to `%TEMP%`, then the user's Desktop if neither is writable):
 
 ```
 Optimizer_Log_YYYYMMDD_HHMMSS.txt
@@ -155,13 +155,13 @@ Optimizer_Log_YYYYMMDD_HHMMSS.txt
 
 This log contains timestamped entries for every action, warning, fix, and skip that occurred during the run.
 
-An undo file is also saved to the desktop after optimization:
+An undo file is written to the same directory after optimization:
 
 ```
 undo_YYYYMMDD_HHMMSS.json
 ```
 
-This JSON file records the previous value of every registry key that was modified, allowing full rollback with the `-Undo` parameter.
+This JSON file records the previous value of every registry key that was modified, allowing full rollback with the `-Undo` parameter. The file's ACL is tightened after write so only the current user can read it (the JSON contains enough configuration detail that it shouldn't be world-readable on a shared machine).
 
 ## Disclaimer
 

--- a/Ultimate-Windows-System-Optimizer.ps1
+++ b/Ultimate-Windows-System-Optimizer.ps1
@@ -10,7 +10,8 @@
     tweaks, Explorer improvements, SSD-specific tuning, and security hardening.
 
     The script creates a System Restore Point before making any changes and generates
-    a timestamped log file on the desktop.
+    a timestamped log file in %LOCALAPPDATA%\UWSO (with fallback to %TEMP% then Desktop
+    if that path isn't writable).
 
 .PARAMETER Only
     Run only the specified optimization sections. Valid values: Cleanup, Services, Power,
@@ -34,7 +35,7 @@
     Author       : TiltedLunar123
     Requires     : Windows 10 or 11, PowerShell 5.1+, Administrator privileges
     Restore Point: Created automatically before optimization begins
-    Log File     : Saved to Desktop as Optimizer_Log_YYYYMMDD_HHMMSS.txt
+    Log File     : Optimizer_Log_YYYYMMDD_HHMMSS.txt under %LOCALAPPDATA%\UWSO
 
 .EXAMPLE
     # Run all optimizations:
@@ -69,7 +70,6 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Continue'
 $ProgressPreference    = 'SilentlyContinue'
-$LogFile = "$env:USERPROFILE\Desktop\Optimizer_Log_$(Get-Date -Format 'yyyyMMdd_HHmmss').txt"
 $RestorePoint = $true
 
 # ── IMPORT MODULES ──────────────────────────────────────────────
@@ -85,6 +85,11 @@ Import-Module (Join-Path $modulesPath "Network.psm1")    -Force -DisableNameChec
 Import-Module (Join-Path $modulesPath "Performance.psm1") -Force -DisableNameChecking
 Import-Module (Join-Path $modulesPath "Security.psm1")   -Force -DisableNameChecking
 Import-Module (Join-Path $modulesPath "Explorer.psm1")   -Force -DisableNameChecking
+
+# Log path is resolved after Config.psm1 is loaded so we can use the
+# data-dir helper. Desktop is unreliable on enterprise configs (folder
+# redirected to a network share, marked read-only, or absent entirely).
+$LogFile = Join-Path (Get-OptimizerDataDir) ("Optimizer_Log_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + ".txt")
 
 # ── UNDO MODE ───────────────────────────────────────────────────
 if ($Undo) {

--- a/modules/Config.psm1
+++ b/modules/Config.psm1
@@ -66,6 +66,41 @@ function Get-DryRunMode {
     return $script:DryRunMode
 }
 
+function Get-OptimizerDataDir {
+    # Returns a writable directory for optimizer artifacts (log, undo
+    # JSON). Prefers $env:LOCALAPPDATA\UWSO because NTFS ACLs already
+    # restrict it to the current user. Falls back to $env:TEMP, then the
+    # user's Desktop as a last resort. Verifies write access by touching
+    # a probe file before returning - covers redirected-to-readonly
+    # Desktop, full TEMP volumes, etc.
+    $candidates = @()
+    if ($env:LOCALAPPDATA) { $candidates += (Join-Path $env:LOCALAPPDATA 'UWSO') }
+    if ($env:TEMP)         { $candidates += $env:TEMP }
+    if ($env:USERPROFILE)  { $candidates += (Join-Path $env:USERPROFILE 'Desktop') }
+
+    foreach ($dir in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($dir)) { continue }
+        try {
+            if (-not (Test-Path -LiteralPath $dir)) {
+                New-Item -ItemType Directory -Path $dir -Force -ErrorAction Stop | Out-Null
+            }
+            $probe = Join-Path $dir (".uwso_probe_" + [Guid]::NewGuid().ToString('N'))
+            Set-Content -LiteralPath $probe -Value 'probe' -ErrorAction Stop
+            Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+            return $dir
+        } catch {
+            continue
+        }
+    }
+
+    # Every candidate failed - return the first non-empty so callers
+    # have a path to surface in their own error messages.
+    foreach ($dir in $candidates) {
+        if (-not [string]::IsNullOrWhiteSpace($dir)) { return $dir }
+    }
+    return $env:TEMP
+}
+
 function Set-RegValue {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -127,4 +162,4 @@ function Test-SectionEnabled {
 
 Export-ModuleMember -Function Set-RegValue, Get-ValidSectionList, Get-BloatServiceDefinition,
     Get-BloatScheduledTaskList, Get-FeaturesToDisable, Test-SectionEnabled,
-    Set-DryRunMode, Get-DryRunMode
+    Set-DryRunMode, Get-DryRunMode, Get-OptimizerDataDir

--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -296,29 +296,56 @@ function Invoke-DiskOptimization {
 
     Write-Host "`n    -- Disk Optimization --" -ForegroundColor Cyan
 
+    # Iterate every fixed volume with a drive letter. The previous
+    # implementation hardcoded C:, which silently skipped multi-drive
+    # systems (e.g. Windows on D:, secondary HDD on E:). Optimize-Volume
+    # -ReTrim is a safe no-op on non-SSD media, and defrag.exe with the
+    # arguments split (rather than crammed into one quoted string) is
+    # what the docs actually expect.
+    $fixedVolumes = @()
+    if (Get-Command Get-Volume -ErrorAction SilentlyContinue) {
+        try {
+            $fixedVolumes = @(Get-Volume -ErrorAction Stop |
+                Where-Object { $_.DriveType -eq 'Fixed' -and $_.DriveLetter })
+        } catch {
+            $fixedVolumes = @()
+        }
+    }
+
+    if (-not $fixedVolumes) {
+        Write-Skip "No fixed volumes with a drive letter detected"
+        return
+    }
+
     if ($Analysis.HasSSD) {
         if ($DryRun) {
-            Write-Dry "Would run TRIM on SSD"
+            Write-Dry ("Would run TRIM on fixed volumes: " + (($fixedVolumes | ForEach-Object { "$($_.DriveLetter):" }) -join ', '))
         } else {
-            Write-Host "      Running TRIM on SSDs..." -ForegroundColor DarkGray
-            try {
-                Optimize-Volume -DriveLetter C -ReTrim -ErrorAction Stop
-                Write-Fix "TRIM executed on SSD"
-            } catch {
-                Write-Skip "Could not run TRIM on SSD"
+            foreach ($vol in $fixedVolumes) {
+                $letter = $vol.DriveLetter
+                Write-Host "      Running TRIM on ${letter}: ..." -ForegroundColor DarkGray
+                try {
+                    Optimize-Volume -DriveLetter $letter -ReTrim -ErrorAction Stop
+                    Write-Fix "TRIM executed on ${letter}:"
+                } catch {
+                    Write-Skip "Could not run TRIM on ${letter}:"
+                }
             }
         }
     }
     if ($Analysis.HasHDD) {
         if ($DryRun) {
-            Write-Dry "Would start HDD defragmentation"
+            Write-Dry ("Would start HDD defragmentation on fixed volumes: " + (($fixedVolumes | ForEach-Object { "$($_.DriveLetter):" }) -join ', '))
         } else {
-            Write-Host "      HDD defrag will run in background..." -ForegroundColor DarkGray
-            try {
-                Start-Process -FilePath "defrag.exe" -ArgumentList "C: /O /U" -WindowStyle Hidden -ErrorAction Stop
-                Write-Fix "HDD defragmentation started in background"
-            } catch {
-                Write-Skip "Could not start HDD defragmentation"
+            foreach ($vol in $fixedVolumes) {
+                $letter = $vol.DriveLetter
+                Write-Host "      Defrag will run in background on ${letter}: ..." -ForegroundColor DarkGray
+                try {
+                    Start-Process -FilePath "defrag.exe" -ArgumentList "${letter}:", "/O", "/U" -WindowStyle Hidden -ErrorAction Stop
+                    Write-Fix "HDD defragmentation started on ${letter}:"
+                } catch {
+                    Write-Skip "Could not start HDD defragmentation on ${letter}:"
+                }
             }
         }
     }

--- a/modules/UndoManager.psm1
+++ b/modules/UndoManager.psm1
@@ -36,11 +36,19 @@ function Save-RegistryState {
 
 function Export-UndoFile {
     param(
-        [string]$OutputDir = "$env:USERPROFILE\Desktop"
+        [string]$OutputDir
     )
 
     if ($script:UndoEntries.Count -eq 0) {
         return $null
+    }
+
+    if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+        if (Get-Command Get-OptimizerDataDir -ErrorAction SilentlyContinue) {
+            $OutputDir = Get-OptimizerDataDir
+        } else {
+            $OutputDir = $env:TEMP
+        }
     }
 
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
@@ -61,7 +69,41 @@ function Export-UndoFile {
     }
 
     $exportData | ConvertTo-Json -Depth 5 | Out-File -FilePath $filePath -Encoding UTF8 -Force
+    Set-UndoFileAcl -FilePath $filePath
     return $filePath
+}
+
+function Set-UndoFileAcl {
+    # Lock the undo JSON down to the current user. The file lists every
+    # registry path the optimizer touched, which is enough system-config
+    # detail that it shouldn't be world-readable on a shared machine.
+    # Failure to set the ACL is logged, not fatal - the file still
+    # exists and the optimization run is otherwise complete.
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$FilePath)
+
+    if (-not (Test-Path -LiteralPath $FilePath)) { return }
+    if (-not $PSCmdlet.ShouldProcess($FilePath, "Restrict ACL to current user")) { return }
+
+    try {
+        $acl = Get-Acl -LiteralPath $FilePath
+        $acl.SetAccessRuleProtection($true, $false)
+        foreach ($rule in @($acl.Access)) {
+            [void]$acl.RemoveAccessRule($rule)
+        }
+        $userSid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
+        $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+            $userSid,
+            [System.Security.AccessControl.FileSystemRights]::FullControl,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        )
+        $acl.AddAccessRule($rule)
+        Set-Acl -LiteralPath $FilePath -AclObject $acl
+    } catch {
+        if (Get-Command Log -ErrorAction SilentlyContinue) {
+            Log "[WARN] Could not restrict ACL on undo file '$FilePath': $_"
+        }
+    }
 }
 
 function Restore-FromUndoFile {
@@ -117,4 +159,4 @@ function Clear-UndoEntry {
 }
 
 Export-ModuleMember -Function Save-RegistryState, Export-UndoFile, Restore-FromUndoFile,
-    Get-UndoEntry, Clear-UndoEntry
+    Get-UndoEntry, Clear-UndoEntry, Set-UndoFileAcl

--- a/tests/Optimizer.Tests.ps1
+++ b/tests/Optimizer.Tests.ps1
@@ -155,3 +155,32 @@ Describe "UI Functions" {
         $report | Should -Not -BeNullOrEmpty
     }
 }
+
+Describe "Get-OptimizerDataDir" {
+    It "Should return a non-empty path" {
+        $dir = Get-OptimizerDataDir
+        $dir | Should -Not -BeNullOrEmpty
+    }
+
+    It "Should return a path that exists on disk" {
+        $dir = Get-OptimizerDataDir
+        Test-Path -LiteralPath $dir | Should -Be $true
+    }
+
+    It "Should return a writable directory" {
+        $dir = Get-OptimizerDataDir
+        $probe = Join-Path $dir (".uwso_test_probe_" + [Guid]::NewGuid().ToString('N'))
+        { Set-Content -LiteralPath $probe -Value 'x' -ErrorAction Stop } | Should -Not -Throw
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Should prefer LOCALAPPDATA\\UWSO when that path is writable" {
+        if (-not $env:LOCALAPPDATA) {
+            Set-ItResult -Skipped -Because "LOCALAPPDATA not set in this environment"
+            return
+        }
+        $expected = Join-Path $env:LOCALAPPDATA 'UWSO'
+        $dir = Get-OptimizerDataDir
+        $dir | Should -Be $expected
+    }
+}


### PR DESCRIPTION
Three small fixes plus a shared helper. All three issues have the same
shape: the script bakes in an assumption (`Desktop is writable`,
`Desktop ACLs are fine`, `C: is the only drive`) that doesn't survive
contact with real environments.

## Changes

- **`Get-OptimizerDataDir` helper** (`modules/Config.psm1`). Picks
  `%LOCALAPPDATA%\UWSO`, falls back to `%TEMP%`, last resort
  `%USERPROFILE%\Desktop`. Creates the directory and probes write
  access before returning. Four Pester cases cover it.

- **Log file goes under `%LOCALAPPDATA%\UWSO`** (Optimizer entry
  point). Closes #23. Folder-redirected Desktop on enterprise configs
  was silently breaking log writes.

- **Undo file goes under `%LOCALAPPDATA%\UWSO` with a tightened ACL**
  (`modules/UndoManager.psm1`). Closes #12. Default `OutputDir`
  resolves through the helper, and `Set-UndoFileAcl` strips inherited
  entries and grants `FullControl` only to the current user SID.
  Failure to apply the ACL is logged, not thrown.

- **`Invoke-DiskOptimization` iterates fixed volumes**
  (`modules/Performance.psm1`). Closes #5 and #27. Two bugs in the
  same block: TRIM and defrag both ran against C: only, and
  `defrag.exe` was launched with `"C: /O /U"` as a single quoted arg
  so the flags were being parsed as part of the volume name. Now we
  enumerate `Get-Volume -DriveType Fixed` (with a drive letter), call
  `Optimize-Volume -ReTrim` per volume when `HasSSD`, and launch
  `defrag.exe` with letter, `/O`, `/U` as separate arguments when
  `HasHDD`.

- **README**: Output section and `-Undo` example reflect the new path
  and ACL behavior.

## Verification

- Local: Pester 46/47 (unchanged from baseline; the one failure is a
  pre-existing `Should -Throw` test on `Restore-FromUndoFile` that's
  been failing before this branch and is untouched here).
  PSScriptAnalyzer clean (warnings + errors, with the existing
  `PSAvoidUsingWriteHost` and `PSUseBOMForUnicodeEncodedFile`
  exclusions).
- Forbidden-term and secret scans clean against the full branch diff
  and every commit message.

## Out of scope

Big-shape issues that need their own PRs:
- #28 unbounded recursive cleanup of WINDIR\Temp
- #13 Set-RegValue path validation (touches every module)
- #14, #2, #7, #8 undo-coverage gaps
- #18 module test coverage

Closes #5
Closes #12
Closes #23
Closes #27