### PR TITLE
Three small bug fixes around undo type, DryRun reporting, and registry path validation

### DIFF
--- a/modules/Config.psm1
+++ b/modules/Config.psm1
@@ -101,6 +101,28 @@ function Get-OptimizerDataDir {
     return $env:TEMP
 }
 
+# Hive prefixes Set-RegValue is allowed to touch. Anything else is
+# almost certainly a typo or a bug in the caller, and silently creating
+# arbitrary registry keys is exactly the kind of thing this script
+# should never do. Kept narrow on purpose; add a prefix here if a
+# legitimate need shows up.
+$script:AllowedRegHives = @(
+    'HKCU:\', 'HKLM:\', 'HKCR:\', 'HKU:\', 'HKCC:\'
+)
+
+function Test-RegPathAllowed {
+    [CmdletBinding()]
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return $false }
+    foreach ($prefix in $script:AllowedRegHives) {
+        if ($Path.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return $true
+        }
+    }
+    return $false
+}
+
 function Set-RegValue {
     [CmdletBinding(SupportsShouldProcess)]
     param(
@@ -109,6 +131,13 @@ function Set-RegValue {
         $Value,
         [string]$Type = "DWord"
     )
+
+    if (-not (Test-RegPathAllowed -Path $Path)) {
+        if (Get-Command Log -ErrorAction SilentlyContinue) {
+            Log "[ERROR] Rejected registry path '$Path' - must start with one of: $($script:AllowedRegHives -join ', ')"
+        }
+        return $false
+    }
 
     # Save state for undo before making changes
     Save-RegistryState -Path $Path -Name $Name -NewValue $Value -Type $Type
@@ -162,4 +191,4 @@ function Test-SectionEnabled {
 
 Export-ModuleMember -Function Set-RegValue, Get-ValidSectionList, Get-BloatServiceDefinition,
     Get-BloatScheduledTaskList, Get-FeaturesToDisable, Test-SectionEnabled,
-    Set-DryRunMode, Get-DryRunMode, Get-OptimizerDataDir
+    Set-DryRunMode, Get-DryRunMode, Get-OptimizerDataDir, Test-RegPathAllowed

--- a/modules/Explorer.psm1
+++ b/modules/Explorer.psm1
@@ -7,23 +7,24 @@ function Invoke-ExplorerOptimization {
     Write-Host "`n    -- Explorer & UI Tweaks --" -ForegroundColor Cyan
 
     $advPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"
+    $isDry = Get-DryRunMode
 
     Set-RegValue $advPath "HideFileExt" 0
-    Write-Fix "File extensions now visible"
+    if (-not $isDry) { Write-Fix "File extensions now visible" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" "BingSearchEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" "CortanaConsent" 0
-    Write-Fix "Web search in Start Menu disabled"
+    if (-not $isDry) { Write-Fix "Web search in Start Menu disabled" }
 
     Set-RegValue "HKCU:\Control Panel\Desktop" "MenuShowDelay" "50" "String"
-    Write-Fix "Menu animations sped up"
+    if (-not $isDry) { Write-Fix "Menu animations sped up" }
 
     Set-RegValue $advPath "ShowRecent" 0
     Set-RegValue $advPath "ShowFrequent" 0
-    Write-Fix "Recent and frequent items hidden"
+    if (-not $isDry) { Write-Fix "Recent and frequent items hidden" }
 
     Set-RegValue $advPath "LaunchTo" 1 "DWord"
-    Write-Fix "Explorer opens to 'This PC' - faster navigation"
+    if (-not $isDry) { Write-Fix "Explorer opens to 'This PC' - faster navigation" }
 }
 
 function Invoke-ContextMenuOptimization {
@@ -31,9 +32,11 @@ function Invoke-ContextMenuOptimization {
 
     Write-Host "`n    -- Shell & Context Menu Tweaks --" -ForegroundColor Cyan
 
+    $isDry = Get-DryRunMode
+
     if ([int]$Analysis.OSBuild -ge 22000) {
         $ctxPath = "HKCU:\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32"
-        if (Get-DryRunMode) {
+        if ($isDry) {
             Write-Dry "Would restore classic right-click context menu"
         } else {
             try {
@@ -47,7 +50,7 @@ function Invoke-ContextMenuOptimization {
         }
     }
 
-    Write-Fix "Context menu cleaned"
+    if (-not $isDry) { Write-Fix "Context menu cleaned" }
 }
 
 Export-ModuleMember -Function Invoke-ExplorerOptimization, Invoke-ContextMenuOptimization

--- a/modules/UndoManager.psm1
+++ b/modules/UndoManager.psm1
@@ -130,7 +130,9 @@ function Restore-FromUndoFile {
                 if (-not (Test-Path $entry.Path)) {
                     New-Item -Path $entry.Path -Force | Out-Null
                 }
-                Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $value -Force
+                # Older undo files (pre-Type field) default to DWord.
+                $type = if ($entry.PSObject.Properties['Type'] -and $entry.Type) { $entry.Type } else { 'DWord' }
+                Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $value -Type $type -Force
                 $restored++
             } else {
                 # Value didn't exist before, remove it

--- a/tests/Optimizer.Tests.ps1
+++ b/tests/Optimizer.Tests.ps1
@@ -216,3 +216,46 @@ Describe "Explorer DryRun output" {
     }
 }
 
+Describe "Set-RegValue path validation" {
+    # Issue #13: Set-RegValue would create keys at any path string. Reject
+    # anything not under a standard hive prefix so a bad caller can't
+    # scatter keys around the registry.
+    BeforeEach {
+        Set-DryRunMode $true
+        Clear-UndoEntry
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+    }
+
+    It "Should accept HKCU: paths" {
+        $result = Set-RegValue "HKCU:\Software\UWSOValidationTest_$(Get-Random)" "X" 1
+        $result | Should -Be $true
+    }
+
+    It "Should accept HKLM: paths" {
+        $result = Set-RegValue "HKLM:\Software\UWSOValidationTest_$(Get-Random)" "X" 1
+        $result | Should -Be $true
+    }
+
+    It "Should accept HKCR: paths" {
+        $result = Set-RegValue "HKCR:\UWSOValidationTest_$(Get-Random)" "X" 1
+        $result | Should -Be $true
+    }
+
+    It "Should reject paths without a hive prefix" {
+        $result = Set-RegValue "Software\UWSOBadPath" "X" 1
+        $result | Should -Be $false
+    }
+
+    It "Should reject paths with a bogus PSDrive prefix" {
+        $result = Set-RegValue "Foo:\Bar" "X" 1
+        $result | Should -Be $false
+    }
+
+    It "Should reject empty or whitespace paths" {
+        (Set-RegValue "" "X" 1)  | Should -Be $false
+        (Set-RegValue "   " "X" 1) | Should -Be $false
+    }
+}

--- a/tests/Optimizer.Tests.ps1
+++ b/tests/Optimizer.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     Import-Module (Join-Path $modulesPath "UndoManager.psm1") -Force -DisableNameChecking
     Import-Module (Join-Path $modulesPath "Config.psm1")      -Force -DisableNameChecking
     Import-Module (Join-Path $modulesPath "Analysis.psm1")    -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Explorer.psm1")    -Force -DisableNameChecking
 }
 
 Describe "Section Filtering with -Only" {
@@ -184,3 +185,34 @@ Describe "Get-OptimizerDataDir" {
         $dir | Should -Be $expected
     }
 }
+
+Describe "Explorer DryRun output" {
+    # Issue #7: every [FIX] line was firing even in DryRun, on top of the
+    # [DRY] line that Set-RegValue already emits. Make sure the fix
+    # counter doesn't move when DryRun is on.
+    BeforeEach {
+        Reset-FixCounter
+        Clear-UndoEntry
+    }
+
+    It "Should not increment fix counter during Invoke-ExplorerOptimization in DryRun" {
+        Set-DryRunMode $true
+        try {
+            Invoke-ExplorerOptimization -Analysis @{ OSBuild = 22000 } | Out-Null
+            Get-FixCount | Should -Be 0
+        } finally {
+            Set-DryRunMode $false
+        }
+    }
+
+    It "Should not increment fix counter during Invoke-ContextMenuOptimization in DryRun" {
+        Set-DryRunMode $true
+        try {
+            Invoke-ContextMenuOptimization -Analysis @{ OSBuild = 22000 } | Out-Null
+            Get-FixCount | Should -Be 0
+        } finally {
+            Set-DryRunMode $false
+        }
+    }
+}
+

--- a/tests/UndoManager.Tests.ps1
+++ b/tests/UndoManager.Tests.ps1
@@ -83,4 +83,66 @@ Describe "Undo File Restore" {
         # Cleanup
         Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
     }
+
+    It "Should preserve the registry value type when restoring (String stays String)" {
+        $testPath = "HKCU:\Software\UWSOTestRestore_$(Get-Random)"
+        $tempFile = Join-Path $env:TEMP "test_undo_type_$(Get-Random).json"
+
+        # Pre-create a String value so Existed = true and OldValue is the string.
+        New-Item -Path $testPath -Force | Out-Null
+        Set-ItemProperty -Path $testPath -Name "MyVal" -Value "original" -Type String -Force
+
+        $data = @(
+            @{
+                Path     = $testPath
+                Name     = "MyVal"
+                NewValue = "changed"
+                OldValue = "original"
+                Type     = "String"
+                Existed  = $true
+                IsBase64 = $false
+            }
+        )
+        $data | ConvertTo-Json -Depth 5 | Out-File $tempFile -Encoding UTF8
+
+        # Simulate optimizer overwriting it as a different type.
+        Set-ItemProperty -Path $testPath -Name "MyVal" -Value 0 -Type DWord -Force
+
+        Restore-FromUndoFile -FilePath $tempFile | Out-Null
+
+        $kind = (Get-Item -Path $testPath).GetValueKind("MyVal")
+        $kind | Should -Be "String"
+        (Get-ItemProperty -Path $testPath -Name "MyVal")."MyVal" | Should -Be "original"
+
+        Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Should default to DWord when an older undo file has no Type field" {
+        $testPath = "HKCU:\Software\UWSOTestRestore_$(Get-Random)"
+        $tempFile = Join-Path $env:TEMP "test_undo_legacy_$(Get-Random).json"
+
+        New-Item -Path $testPath -Force | Out-Null
+
+        # Legacy entry: no Type field at all.
+        $data = @(
+            [pscustomobject]@{
+                Path     = $testPath
+                Name     = "LegacyVal"
+                NewValue = 1
+                OldValue = 0
+                Existed  = $true
+                IsBase64 = $false
+            }
+        )
+        $data | ConvertTo-Json -Depth 5 | Out-File $tempFile -Encoding UTF8
+
+        Restore-FromUndoFile -FilePath $tempFile | Out-Null
+
+        $kind = (Get-Item -Path $testPath).GetValueKind("LegacyVal")
+        $kind | Should -Be "DWord"
+
+        Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
 }


### PR DESCRIPTION
Three independent small fixes against open issues. Each is contained to
one or two files and backed by tests.

## Changes

- **Restore-FromUndoFile now passes Type through.** A DWord value
  saved as 0 was coming back as a String on rollback because the
  `-Type` field never made it into the `Set-ItemProperty` call.
  Older undo files without a Type field fall back to DWord. Closes #6.

- **Explorer DryRun output no longer double-reports.** `Set-RegValue`
  already prints a `[DRY]` line, but the `Write-Fix` calls in
  `Invoke-ExplorerOptimization` and `Invoke-ContextMenuOptimization`
  were unconditional, so every dry-run change showed up twice and
  inflated the fix counter. The Write-Fix calls now check
  `Get-DryRunMode`. Closes #7.

- **Set-RegValue rejects paths outside the standard hives.** Path
  must start with HKCU:, HKLM:, HKCR:, HKU:, or HKCC:. Anything else
  is logged and the function returns false. `Test-RegPathAllowed` is
  exported so callers can validate before invoking. Closes #13.

## Tests

- Two new cases in `UndoManager.Tests.ps1` cover the Type round-trip
  (String stays String) and the legacy-file fallback (no Type ->
  DWord).
- New `Explorer DryRun output` block in `Optimizer.Tests.ps1`
  asserts the fix counter stays at zero after a dry-run pass through
  both Explorer functions.
- New `Set-RegValue path validation` block covers each allowed hive
  prefix plus malformed, drive-less, and empty paths.

## Follow-ups (not in this PR)

- Issue #8 (Privacy/Performance/etc. ignoring DryRun) is the same
  shape as #7 but spans more modules. Worth its own pass.
- Issue #20 (WSearch dependency check) needs design discussion.
- The pre-existing `Should fail gracefully with non-existent file`
  test in `UndoManager.Tests.ps1` is broken (expects throw but
  `Write-Error` is non-terminating). CI passes only because
  `Invoke-Pester` isn't called with `Run.Exit = $true`. Separate fix.