### PR TITLE
v4.0: fix open issues, harden safety, add presets/report/undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ enhancement issues and adds presets, a JSON report, and richer undo.
   JSON and fails gracefully instead of throwing.
 - External tool failures (`fsutil`, `netsh`, `bcdedit`) are reported as skips
   rather than false successes.
+- Stray `True` console output is suppressed (the boolean `Set-RegValue` returns
+  no longer leaks to the screen during a run).
+- The post-optimization telemetry/visual-effects re-checks no longer throw
+  `PropertyNotFoundStrict` under `Set-StrictMode` when the value is absent
+  (surfaced by a real elevated run).
 
 ### Changed
 - **Windows Search Indexer (WSearch) is no longer disabled by default** (#20):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable changes to this project are documented here. This project adheres
+to [Semantic Versioning](https://semver.org/).
+
+## [4.0.0] - 2026-05-25
+
+A correctness, safety, and feature release. Closes the open bug, security, and
+enhancement issues and adds presets, a JSON report, and richer undo.
+
+### Added
+- **Optimization presets** via `-Preset`: `Balanced` (all sections), `Gaming`,
+  `Privacy`, and `Minimal`. Composes with `-Skip`; `-Only` overrides.
+- **Check-only mode** (`-CheckOnly`): analyze and score the system, then exit
+  without making any changes, restore point, or undo file.
+- **JSON report** (`report_YYYYMMDD_HHMMSS.json`) written next to the log with
+  device profile, tier, preset, sections run, before/after scores, fix count,
+  and duration.
+- **Undo conveniences**: `-Undo Latest` restores the most recent run and
+  `-ListUndo` lists available undo files.
+- **Non-registry undo** (#2): service startup types, scheduled task states,
+  optional feature states, the boot menu timeout, and optimizer-created
+  registry keys are now captured and restorable.
+- **Restore-point verification**: the run confirms a restore point actually
+  exists and warns (rather than implying rollback) when System Protection is off.
+- Pure, unit-tested helpers `Get-SystemTier`, `Get-PowerPlanName`, and
+  `Get-OSBuildNumber`. Pester coverage expanded to 84 tests, including a
+  DryRun no-mutation integration test and cleanup age-filter tests (#18).
+
+### Fixed
+- **Power plan name parsing**: modern `powercfg` prints the plan in
+  parentheses, but the old regex expected quotes, so the active plan was always
+  reported as "Unknown". This corrupted the analysis readout and the health
+  score; both are now accurate.
+- **Post-optimization score** is computed from a consistent schema (it no longer
+  drops keys like `IsLaptop`), so before/after scores are comparable.
+- **DryRun no longer inflates the fix counter** (#8): Privacy, Performance,
+  Network, Security, Notifications, and BackgroundApps now gate their `[FIX]`
+  output on DryRun.
+- **Temp cleanup is safe** (#3, #28): only files older than 24h are removed, one
+  file at a time (locked/in-use files are skipped instead of wedging Windows
+  servicing), reparse points are skipped, freed-space totals are accurate, and
+  the optimizer's own data directory is excluded.
+- **Context-menu restoration is undoable** (#14): the Windows 11 classic
+  context-menu key is recorded so rollback removes it.
+- **NDU disable** targets `CurrentControlSet` instead of a hardcoded
+  `ControlSet001` that could silently no-op.
+- Undo entries are **de-duplicated**, preserving the genuine pre-run value when
+  a key is written by more than one section; `Restore-FromUndoFile` validates
+  JSON and fails gracefully instead of throwing.
+- External tool failures (`fsutil`, `netsh`, `bcdedit`) are reported as skips
+  rather than false successes.
+
+### Changed
+- **Windows Search Indexer (WSearch) is no longer disabled by default** (#20):
+  Start Menu, File Explorer, Outlook, Teams, and OneNote all depend on it.
+- **Fast Startup is skipped on dual-boot systems** and when hibernation is
+  unavailable (#22), avoiding NTFS corruption and inert settings.
+- `Set-RegValue` validates the registry value type before writing.
+- Documentation corrected: log/report location, module map, and undo coverage.
+
+### Security
+- **run.ps1 no longer re-downloads on elevation** (#10): it downloads once and
+  elevates the local copy, closing a time-of-check/time-of-use gap.
+- **run.ps1 integrity** (#11): the installer prints the archive SHA256 and can
+  fail closed against a pinned hash via `-ExpectedHash` or `$env:UWSO_SHA256`.
+
+## [3.1] and earlier
+
+See the Git history for the v3.x modular refactor, DryRun/Undo introduction,
+and the initial release.

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ A PowerShell script that analyzes Windows 10/11 systems and applies intelligent,
 - **Scheduled task cleanup** - disables compatibility appraiser, CEIP, disk diagnostics, maps updates, and error reporting tasks
 - **Boot optimization** - enables Fast Startup, reduces boot timeout, enables verbose boot messages
 - **Security hardening** - disables Remote Desktop, Remote Assistance, SMBv1, and AutoRun; verifies Windows Firewall is enabled
-- **Context-aware safety** - skips changes that would break detected hardware or active sessions (Outlook, RDP, printers, touchscreens)
-- **Undo/rollback** - exports all registry changes to a JSON file that can restore previous values
+- **Context-aware safety** - skips changes that would break detected hardware or active sessions (RDP, printers, touchscreens, dual-boot)
+- **Undo/rollback** - exports registry *and* non-registry changes (services, scheduled tasks, optional features, boot timeout) to a JSON file that can be restored later
 - **Dry run mode** - preview all changes without modifying anything
-- **Selective optimization** - run only specific sections or skip sections you don't want
-- **Restore point creation** - automatically creates a System Restore Point before making any changes
-- **Detailed logging** - saves a timestamped log file to the desktop
+- **Selective optimization** - run only specific sections, skip sections you don't want, or pick a named preset
+- **Optimization presets** - `Balanced` (all), `Gaming`, `Privacy`, and `Minimal`
+- **Check-only mode** - analyze and score the system without making any changes
+- **Restore point creation** - creates a System Restore Point before making changes (and verifies it actually exists)
+- **Detailed logging** - saves a timestamped log file and a machine-readable JSON report under `%LOCALAPPDATA%\UWSO`
 
 ## Requirements
 
@@ -44,13 +46,23 @@ irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Opt
 ```
 
 That's it. The script will:
-1. Request administrator privileges (UAC prompt)
-2. Download the latest version
-3. Create a System Restore Point so changes can be rolled back
+1. Download the latest version to a temp folder and print its SHA256
+2. Request administrator privileges (UAC prompt) and run the local copy
+3. Create a System Restore Point (when System Protection is enabled)
 4. Analyze your system
 5. Apply all optimizations
 6. Show before/after health scores
 7. Clean up temp files
+
+> **Security note:** this command downloads and runs code that then elevates to
+> administrator. Review `run.ps1` and the repository before running. The
+> installer downloads the archive once (it does not re-download in the elevated
+> shell) and prints the archive's SHA256. To fail closed on tampering, pin a
+> known-good hash:
+>
+> ```powershell
+> $env:UWSO_SHA256 = '<hash printed on a trusted run>'; irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex
+> ```
 
 ## Manual Usage
 
@@ -72,7 +84,10 @@ If you prefer to clone and run manually:
 | `-DryRun` | Switch | Preview all changes without modifying anything. Shows what WOULD happen. |
 | `-Only` | String[] | Run only the specified sections. Example: `-Only "Privacy","Cleanup"` |
 | `-Skip` | String[] | Run all sections except the specified ones. Example: `-Skip "Security","Network"` |
-| `-Undo` | String | Path to a previously generated undo JSON file. Restores all registry values. |
+| `-Preset` | String | Run a named preset instead of all sections: `Balanced`, `Gaming`, `Privacy`, `Minimal`. Composes with `-Skip`; `-Only` overrides. |
+| `-CheckOnly` | Switch | Analyze and score only, then exit. Makes no changes, no restore point, no undo file. |
+| `-Undo` | String | Path to an undo JSON file, or the literal `Latest` to restore the most recent run. Restores registry **and** non-registry changes. |
+| `-ListUndo` | Switch | List available undo files (newest first) and exit. |
 | `-Force` | Switch | Skip per-section confirmation prompts. Runs all enabled sections without asking. |
 
 ### Valid Section Names
@@ -94,7 +109,17 @@ If you prefer to clone and run manually:
 # Run everything except security:
 .\Ultimate-Windows-System-Optimizer.ps1 -Skip "Security"
 
-# Restore from undo file:
+# Run the Gaming preset:
+.\Ultimate-Windows-System-Optimizer.ps1 -Preset Gaming
+
+# Analyze and score only, change nothing:
+.\Ultimate-Windows-System-Optimizer.ps1 -CheckOnly
+
+# List undo files, then roll back the most recent run:
+.\Ultimate-Windows-System-Optimizer.ps1 -ListUndo
+.\Ultimate-Windows-System-Optimizer.ps1 -Undo Latest
+
+# Restore from a specific undo file:
 .\Ultimate-Windows-System-Optimizer.ps1 -Undo "$env:LOCALAPPDATA\UWSO\undo_20260329_120000.json"
 ```
 
@@ -105,15 +130,15 @@ The optimizer is split into a modular architecture for maintainability and testa
 ```
 Ultimate-Windows-System-Optimizer.ps1   # Entry point, orchestration, parameter handling
 modules/
-  Config.psm1          # Shared constants, tier definitions, Set-RegValue helper
+  Config.psm1          # Shared constants, bloat lists, presets, Set-RegValue helper
   UI.psm1              # Banner, section headers, status output, colors, logging
-  UndoManager.psm1     # Save registry state before changes, restore from JSON
+  UndoManager.psm1     # Save registry + non-registry state before changes, restore from JSON
   Analysis.psm1        # Phase 1 - hardware/disk/temp/startup/services/power analysis + scoring
   Cleanup.psm1         # Temp files, disk cleanup, recycle bin
   Services.psm1        # Bloat service detection and disabling
   Privacy.psm1         # Telemetry, ads, tracking, content delivery, feedback
   Network.psm1         # Nagle, TCP, DNS, network throttling
-  Performance.psm1     # Gaming, visual effects, memory, GPU, boot, scheduled tasks, background apps
+  Performance.psm1     # Power, gaming, visual effects, memory, GPU, SSD, disk, boot, scheduled tasks, background apps, notifications, features
   Security.psm1        # RDP, SMB, firewall, autorun
   Explorer.psm1        # Shell tweaks, context menu, file extensions, search
 tests/
@@ -124,13 +149,13 @@ tests/
   ci.yml               # PSScriptAnalyzer lint + Pester tests on push/PR
 ```
 
-Each optimization module exports a single `Invoke-*Optimization` function. The analysis module exports `Get-SystemAnalysis` (returns a results hashtable) and `Get-HealthScore` (computes score from results). The undo manager exports `Save-RegistryState`, `Export-UndoFile`, and `Restore-FromUndoFile`.
+Each optimization module exports a single `Invoke-*Optimization` function. The analysis module exports `Get-SystemAnalysis` (returns a results hashtable), `Get-HealthScore` (computes score from results), and the pure helpers `Get-SystemTier` and `Get-PowerPlanName`. The undo manager records both registry changes (`Save-RegistryState`, `Save-RegistryKeyState`) and non-registry changes (`Save-ServiceState`, `Save-ScheduledTaskState`, `Save-FeatureState`, `Save-BcdTimeout`), and restores them with `Restore-FromUndoFile` (`-Undo Latest` and `-ListUndo` are driven by `Get-UndoFileList`).
 
 ## What the Script Modifies
 
 | Category | Examples |
 |---|---|
-| Windows services | Telemetry, Xbox, Fax, Geolocation, Search Indexer, etc. |
+| Windows services | Telemetry, Xbox, Fax, Geolocation, etc. (Windows Search is left enabled) |
 | Registry values | Privacy settings, visual effects, power throttling, network tuning |
 | Power configuration | Power plan selection, CPU throttle limits, USB suspend settings |
 | Scheduled tasks | Compatibility appraiser, CEIP, disk diagnostics, map updates |
@@ -151,13 +176,21 @@ Optimizer_Log_YYYYMMDD_HHMMSS.txt
 
 This log contains timestamped entries for every action, warning, fix, and skip that occurred during the run.
 
-An undo file is written to the same directory after optimization:
+A machine-readable JSON report is written alongside the log:
+
+```
+report_YYYYMMDD_HHMMSS.json
+```
+
+It captures the device profile, system tier, preset, sections run, before/after health scores, fix count, and run duration.
+
+An undo file is also written to the same directory after optimization:
 
 ```
 undo_YYYYMMDD_HHMMSS.json
 ```
 
-This JSON file records the previous value of every registry key that was modified, allowing full rollback with the `-Undo` parameter. The file's ACL is tightened after write so only the current user can read it (the JSON contains enough configuration detail that it shouldn't be world-readable on a shared machine).
+This JSON file records the previous state of everything that was modified - registry values and keys, plus non-registry changes (service startup types, scheduled task states, optional feature states, and the boot menu timeout) - allowing rollback with `-Undo <file>` or `-Undo Latest`. The file's ACL is tightened after write so only the current user can read it (the JSON contains enough configuration detail that it shouldn't be world-readable on a shared machine).
 
 ## Disclaimer
 
@@ -174,6 +207,10 @@ Some things to keep in mind:
 - Use the generated undo file to roll back registry changes
 
 **Always review the script before running it on a machine you depend on.**
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes. The current release is **v4.0**.
 
 ## License
 

--- a/Ultimate-Windows-System-Optimizer.ps1
+++ b/Ultimate-Windows-System-Optimizer.ps1
@@ -1,7 +1,7 @@
 #Requires -RunAsAdministrator
 <#
 .SYNOPSIS
-    Ultimate Windows System Optimizer v3.1 — automated performance tuning for Windows 10/11.
+    Ultimate Windows System Optimizer v4.0 - automated performance tuning for Windows 10/11.
 
 .DESCRIPTION
     Performs deep system analysis and applies intelligent optimizations based on detected
@@ -21,17 +21,30 @@
 .PARAMETER Skip
     Skip the specified optimization sections. Same valid values as -Only.
 
+.PARAMETER Preset
+    Run a named preset instead of all sections. Valid values: Balanced (all
+    sections), Gaming, Privacy, Minimal. Composes with -Skip; -Only overrides.
+
 .PARAMETER DryRun
     Show what changes WOULD be made without actually modifying anything.
 
+.PARAMETER CheckOnly
+    Run analysis and the health score only, then exit. Makes no changes,
+    creates no restore point, and writes no undo file.
+
 .PARAMETER Undo
-    Path to a previously generated undo JSON file. Restores all registry values.
+    Path to a previously generated undo JSON file, or the literal value
+    'Latest' to restore the most recent undo file. Restores registry values
+    and non-registry changes (services, scheduled tasks, features, boot timeout).
+
+.PARAMETER ListUndo
+    List available undo files (newest first) and exit.
 
 .PARAMETER Force
     Skip per-section confirmation prompts.
 
 .NOTES
-    Version      : 3.1
+    Version      : 4.0
     Author       : TiltedLunar123
     Requires     : Windows 10 or 11, PowerShell 5.1+, Administrator privileges
     Restore Point: Created automatically before optimization begins
@@ -56,13 +69,29 @@
 .EXAMPLE
     # Restore from undo file:
     .\Ultimate-Windows-System-Optimizer.ps1 -Undo "C:\Users\you\Desktop\undo_20260329_120000.json"
+
+.EXAMPLE
+    # Run the Gaming preset:
+    .\Ultimate-Windows-System-Optimizer.ps1 -Preset Gaming
+
+.EXAMPLE
+    # Analyze and score only, make no changes:
+    .\Ultimate-Windows-System-Optimizer.ps1 -CheckOnly
+
+.EXAMPLE
+    # List undo files, then roll back the most recent run:
+    .\Ultimate-Windows-System-Optimizer.ps1 -ListUndo
+    .\Ultimate-Windows-System-Optimizer.ps1 -Undo Latest
 #>
 
 param(
     [string[]]$Only,
     [string[]]$Skip,
+    [string]$Preset,
     [switch]$DryRun,
+    [switch]$CheckOnly,
     [string]$Undo,
+    [switch]$ListUndo,
     [switch]$Force
 )
 
@@ -91,16 +120,46 @@ Import-Module (Join-Path $modulesPath "Explorer.psm1")   -Force -DisableNameChec
 # redirected to a network share, marked read-only, or absent entirely).
 $LogFile = Join-Path (Get-OptimizerDataDir) ("Optimizer_Log_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + ".txt")
 
+# ── LIST UNDO FILES ─────────────────────────────────────────────
+if ($ListUndo) {
+    Write-Banner
+    Write-Section "AVAILABLE UNDO FILES"
+    $files = Get-UndoFileList
+    if (-not $files -or $files.Count -eq 0) {
+        Write-Host "    No undo files found in $(Get-OptimizerDataDir)" -ForegroundColor Yellow
+    } else {
+        foreach ($f in $files) {
+            Write-Host ("    {0}   {1}" -f $f.LastWriteTime.ToString('yyyy-MM-dd HH:mm:ss'), $f.FullName) -ForegroundColor Gray
+        }
+        Write-Host ""
+        Write-Host "    Restore the newest with:  -Undo Latest" -ForegroundColor Cyan
+    }
+    Write-Host ""
+    return
+}
+
 # ── UNDO MODE ───────────────────────────────────────────────────
 if ($Undo) {
     Write-Banner
     Write-Section "UNDO / ROLLBACK"
-    Write-Host "    Restoring from: $Undo" -ForegroundColor Cyan
-    $success = Restore-FromUndoFile -FilePath $Undo
+
+    $undoPath = $Undo
+    if ($Undo -eq 'Latest') {
+        $latest = Get-UndoFileList | Select-Object -First 1
+        if (-not $latest) {
+            Write-Host "    No undo files found in $(Get-OptimizerDataDir)" -ForegroundColor Yellow
+            Write-Host ""
+            return
+        }
+        $undoPath = $latest.FullName
+    }
+
+    Write-Host "    Restoring from: $undoPath" -ForegroundColor Cyan
+    $success = Restore-FromUndoFile -FilePath $undoPath
     if ($success) {
-        Write-Host "    All registry values restored successfully." -ForegroundColor Green
+        Write-Host "    All changes restored successfully." -ForegroundColor Green
     } else {
-        Write-Host "    Some values could not be restored. Check warnings above." -ForegroundColor Yellow
+        Write-Host "    Some changes could not be restored. Check warnings above." -ForegroundColor Yellow
     }
     Write-Host ""
     return
@@ -124,6 +183,16 @@ if ($Skip) {
         }
     }
 }
+
+# ── VALIDATE PRESET ─────────────────────────────────────────────
+if ($Preset -and -not (Test-PresetName $Preset)) {
+    Write-Host "  ERROR: Invalid preset '$Preset'. Valid presets: $((Get-PresetNameList) -join ', ')" -ForegroundColor Red
+    return
+}
+
+# Resolve which sections run from the preset + -Only/-Skip up front so the
+# value can be shown to the user and reused in the report.
+$enabledSections = Resolve-EnabledSection -PresetName $Preset -Only $Only -Skip $Skip
 
 # ── DRY RUN MODE ────────────────────────────────────────────────
 if ($DryRun) {
@@ -179,6 +248,14 @@ if ($DryRun) {
     Write-Host "  *** DRY RUN MODE - No changes will be made ***" -ForegroundColor DarkYellow
     Write-Host ""
 }
+if ($CheckOnly) {
+    Write-Host "  *** CHECK-ONLY MODE - analysis and health score only, no changes ***" -ForegroundColor DarkYellow
+    Write-Host ""
+}
+if ($Preset) {
+    Write-Host "  Preset: $Preset  ->  $($enabledSections -join ', ')" -ForegroundColor Cyan
+    Write-Host ""
+}
 
 Write-Host "  This script will:" -ForegroundColor White
 Write-Host "    1. Analyze your system hardware & software" -ForegroundColor Gray
@@ -191,7 +268,7 @@ Write-Host "  registry values, and scheduled tasks. Review the README" -Foregrou
 Write-Host "  before proceeding." -ForegroundColor Yellow
 Write-Host ""
 
-if (-not $Force) {
+if (-not $Force -and -not $CheckOnly) {
     if (-not (Confirm-Action "Ready to begin analysis and optimization?")) {
         Write-Host "`n  Cancelled. No changes made." -ForegroundColor Red
         return
@@ -203,6 +280,26 @@ $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 # Phase 1 - Analysis
 $analysisResults = Get-SystemAnalysis
 $beforeScore = Get-HealthScore -AnalysisResults $analysisResults
+
+# Check-only mode: report the score and stop before any changes.
+if ($CheckOnly) {
+    $stopwatch.Stop()
+    Write-Section "CHECK-ONLY COMPLETE"
+    Write-Host ""
+    Write-Host "    Device Type:  $($analysisResults.DeviceType)" -ForegroundColor Gray
+    Write-Host "    System Tier:  $($analysisResults.SystemTier)" -ForegroundColor Gray
+    Write-Host "    Health Score: $beforeScore/100" -ForegroundColor Cyan
+    Write-Host ""
+    Write-Host "    No changes were made. Re-run without -CheckOnly to optimize." -ForegroundColor Gray
+    try {
+        Get-Report | Out-File -FilePath $LogFile -Encoding UTF8 -Force
+        Write-Host "    Log saved to: $LogFile" -ForegroundColor Gray
+    } catch {
+        Write-Host "    Could not save log file to $LogFile" -ForegroundColor Red
+    }
+    Write-Host ""
+    return
+}
 
 if (-not $Force) {
     Write-Host ""
@@ -221,9 +318,21 @@ if ($RestorePoint -and -not $DryRun) {
     try {
         Enable-ComputerRestore -Drive "$env:SystemDrive\" -ErrorAction SilentlyContinue
         Checkpoint-Computer -Description "Pre-Optimizer Backup $(Get-Date -Format 'yyyy-MM-dd HH:mm')" -RestorePointType MODIFY_SETTINGS -ErrorAction Stop
-        Write-Good "Restore point created successfully"
+
+        # Verify a restore point actually exists. System Protection is disabled
+        # by default on many Windows 11/SSD installs, where Checkpoint-Computer
+        # can quietly no-op - don't promise a rollback path that isn't there.
+        $anyPoints = @()
+        if (Get-Command Get-ComputerRestorePoint -ErrorAction SilentlyContinue) {
+            try { $anyPoints = @(Get-ComputerRestorePoint -ErrorAction SilentlyContinue) } catch { $null = $_ }
+        }
+        if ($anyPoints.Count -gt 0) {
+            Write-Good "Restore point available (System Protection is on)"
+        } else {
+            Write-Warn "No restore points found - System Protection may be disabled. The undo file will still capture changes."
+        }
     } catch {
-        Write-Warn "Could not create restore point (may have been created recently)"
+        Write-Warn "Could not create restore point. System Protection may be off; the undo file will still capture changes."
         Log "[ERROR] Restore point creation failed: $_"
     }
 } elseif ($DryRun) {
@@ -232,7 +341,7 @@ if ($RestorePoint -and -not $DryRun) {
 
 # Run each enabled section
 foreach ($sectionName in $sectionMap.Keys) {
-    if (-not (Test-SectionEnabled -SectionName $sectionName -Only $Only -Skip $Skip)) {
+    if ($sectionName -notin $enabledSections) {
         continue
     }
 
@@ -249,29 +358,28 @@ foreach ($sectionName in $sectionMap.Keys) {
 $stopwatch.Stop()
 
 # Export undo file
+$undoFile = $null
 if (-not $DryRun) {
     $undoFile = Export-UndoFile
     if ($undoFile) {
         Write-Host ""
         Write-Good "Undo file saved: $undoFile"
-        Write-Host "    Use -Undo `"$undoFile`" to restore all registry changes" -ForegroundColor Gray
+        Write-Host "    Use -Undo `"$undoFile`" (or -Undo Latest) to roll back changes" -ForegroundColor Gray
     }
 }
 
 # Phase 3 - Re-run analysis for real after-score
 Write-Section "PHASE 3: OPTIMIZATION COMPLETE"
 
-# Re-analyze to get actual post-optimization score
-$postResults = @{
-    RAMUsedPct        = $analysisResults.RAMUsedPct
-    StartupItems      = @(Get-StartupItem)
-    TempSizeMB        = 0  # temp files cleaned
-    ServicesToDisable  = @()
-    TelemetryEnabled  = $false
-    CurrentPowerPlan   = ""
-    Disks             = $analysisResults.Disks
-    VisualEffects      = ""
-}
+# Re-analyze to get the actual post-optimization score. Clone the original
+# analysis so the scorer sees the SAME shape (IsLaptop, Disks, RAM totals,
+# etc.), then overwrite only the fields optimization can change. Building a
+# partial literal here previously dropped keys like IsLaptop, so before and
+# after scores were computed against different schemas.
+$postResults = $analysisResults.Clone()
+$postResults.StartupItems      = @(Get-StartupItem)
+$postResults.TempSizeMB        = 0
+$postResults.ServicesToDisable = @()
 
 # Re-check actual system state for accurate score
 try {
@@ -311,7 +419,7 @@ $postResults.TelemetryEnabled = ($telVal -ne 0)
 
 # Re-check power plan
 $activePlan = powercfg /getactivescheme 2>$null
-$postResults.CurrentPowerPlan = if ($activePlan -match '"([^"]+)"') { $Matches[1] } else { "Unknown" }
+$postResults.CurrentPowerPlan = Get-PowerPlanName (($activePlan | Out-String))
 
 # Re-check visual effects
 $veSetting = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" -Name "VisualFXSetting" -ErrorAction SilentlyContinue).VisualFXSetting
@@ -368,6 +476,36 @@ try {
     Write-Host "       $LogFile" -ForegroundColor White
 } catch {
     Write-Host "    Could not save log file to $LogFile" -ForegroundColor Red
+}
+
+# Machine-readable JSON report alongside the log.
+$report = [ordered]@{
+    Tool            = "Ultimate Windows System Optimizer"
+    Version         = "4.0"
+    TimestampUtc    = (Get-Date).ToUniversalTime().ToString("o")
+    DeviceType      = $analysisResults.DeviceType
+    SystemTier      = $analysisResults.SystemTier
+    OS              = $analysisResults.OSVersion
+    OSBuild         = $analysisResults.OSBuild
+    CPU             = $analysisResults.CPUName
+    TotalRAMGB      = $analysisResults.TotalRAMGB
+    Preset          = if ($Preset) { $Preset } else { "All" }
+    SectionsRun     = @($enabledSections)
+    DryRun          = [bool]$DryRun
+    BeforeScore     = $beforeScore
+    AfterScore      = $newScore
+    FixesApplied    = $fixCount
+    DurationSeconds = [math]::Round($stopwatch.Elapsed.TotalSeconds, 1)
+    Disks           = @($analysisResults.Disks)
+    UndoFile        = $undoFile
+}
+$reportFile = Join-Path (Get-OptimizerDataDir) ("report_" + (Get-Date -Format 'yyyyMMdd_HHmmss') + ".json")
+try {
+    $report | ConvertTo-Json -Depth 5 | Out-File -FilePath $reportFile -Encoding UTF8 -Force
+    Write-Host "    JSON report saved to:" -ForegroundColor Gray
+    Write-Host "       $reportFile" -ForegroundColor White
+} catch {
+    Log "[WARN] Could not write JSON report: $_"
 }
 
 Write-Host ""

--- a/Ultimate-Windows-System-Optimizer.ps1
+++ b/Ultimate-Windows-System-Optimizer.ps1
@@ -352,7 +352,9 @@ foreach ($sectionName in $sectionMap.Keys) {
         }
     }
 
-    & $sectionMap[$sectionName] $analysisResults
+    # Out-Null swallows the $true/$false that Set-RegValue returns to the
+    # output stream (Write-Host/Write-Fix go to the host, so they still show).
+    & $sectionMap[$sectionName] $analysisResults | Out-Null
 }
 
 $stopwatch.Stop()
@@ -413,16 +415,21 @@ foreach ($svc in $bloatSvcs) {
     }
 }
 
-# Re-check telemetry
-$telVal = (Get-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name AllowTelemetry -ErrorAction SilentlyContinue).AllowTelemetry
+# Re-check telemetry. Read the value defensively: under Set-StrictMode,
+# accessing a property that doesn't exist on the returned object throws, and
+# AllowTelemetry is absent on many machines.
+$telItem = Get-ItemProperty "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" -Name AllowTelemetry -ErrorAction SilentlyContinue
+$telVal = if ($telItem -and $telItem.PSObject.Properties['AllowTelemetry']) { $telItem.AllowTelemetry } else { $null }
 $postResults.TelemetryEnabled = ($telVal -ne 0)
 
 # Re-check power plan
 $activePlan = powercfg /getactivescheme 2>$null
 $postResults.CurrentPowerPlan = Get-PowerPlanName (($activePlan | Out-String))
 
-# Re-check visual effects
-$veSetting = (Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" -Name "VisualFXSetting" -ErrorAction SilentlyContinue).VisualFXSetting
+# Re-check visual effects (same StrictMode-safe read - VisualFXSetting is
+# often unset, which previously threw a PropertyNotFoundStrict here).
+$veItem = Get-ItemProperty -Path "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects" -Name "VisualFXSetting" -ErrorAction SilentlyContinue
+$veSetting = if ($veItem -and $veItem.PSObject.Properties['VisualFXSetting']) { $veItem.VisualFXSetting } else { $null }
 $postResults.VisualEffects = switch ($veSetting) { 0 { "Auto" } 1 { "Appearance" } 2 { "Performance" } 3 { "Custom" } default { "Unknown" } }
 
 $newScore = Get-HealthScore -AnalysisResults $postResults

--- a/modules/Analysis.psm1
+++ b/modules/Analysis.psm1
@@ -42,9 +42,30 @@ function Get-StartupItem {
         Log "[ERROR] Could not enumerate scheduled tasks: $_"
     }
 
-    # Stream items so callers see a flat array via @(Get-StartupItem)
-    # rather than a 1-element wrapper that the pipeline then unwraps weirdly.
+    # Callers wrap with @(Get-StartupItem); Get-HealthScore also coerces with
+    # @() before reading .Count, so a 0/1-item result is handled safely.
     return $items
+}
+
+function Get-SystemTier {
+    # Pure tier classification, extracted so it can be unit-tested directly
+    # rather than re-implemented inside the tests.
+    param([double]$RamGB, [int]$Cores)
+
+    if ($RamGB -ge 16 -and $Cores -ge 6) { return "High-End" }
+    elseif ($RamGB -ge 8 -and $Cores -ge 4) { return "Mid-Range" }
+    else { return "Low-End" }
+}
+
+function Get-PowerPlanName {
+    # Extract the active plan name from `powercfg /getactivescheme`. Modern
+    # Windows prints it in parentheses ("... (High performance)"); older
+    # builds used double quotes. Accept both, else return "Unknown".
+    param([string]$PowerCfgOutput)
+
+    if ($PowerCfgOutput -match '\(([^)]+)\)') { return $Matches[1] }
+    if ($PowerCfgOutput -match '"([^"]+)"')   { return $Matches[1] }
+    return "Unknown"
 }
 
 function Get-SystemAnalysis {
@@ -118,13 +139,7 @@ function Get-SystemAnalysis {
     Write-Info "Uptime"             "$([math]::Round(((Get-Date) - $os.LastBootUpTime).TotalHours, 1)) hours"
 
     # Categorize system tier
-    if ($results.TotalRAMGB -ge 16 -and $results.CPUCores -ge 6) {
-        $results.SystemTier = "High-End"
-    } elseif ($results.TotalRAMGB -ge 8 -and $results.CPUCores -ge 4) {
-        $results.SystemTier = "Mid-Range"
-    } else {
-        $results.SystemTier = "Low-End"
-    }
+    $results.SystemTier = Get-SystemTier -RamGB $results.TotalRAMGB -Cores $results.CPUCores
     Write-Info "System Tier"  $results.SystemTier
 
     # -- 1.2 DISK ANALYSIS --
@@ -260,25 +275,9 @@ function Get-SystemAnalysis {
         $bloatServices = $bloatServices | Where-Object { $_.Name -ne "SysMain" }
     }
 
-    # Context-aware: don't flag WSearch if Outlook is installed.
-    # Test-Path doesn't expand wildcards in registry providers, so we walk the
-    # version subkeys (15.0, 16.0, ...) and look for an Outlook child explicitly.
-    $outlookInstalled = $false
-    foreach ($officeRoot in @("HKLM:\SOFTWARE\Microsoft\Office", "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Office")) {
-        if (-not (Test-Path $officeRoot)) { continue }
-        $versionKeys = Get-ChildItem $officeRoot -ErrorAction SilentlyContinue
-        foreach ($vk in $versionKeys) {
-            if (Test-Path (Join-Path $vk.PSPath "Outlook")) {
-                $outlookInstalled = $true
-                break
-            }
-        }
-        if ($outlookInstalled) { break }
-    }
-    if ($outlookInstalled) {
-        $bloatServices = $bloatServices | Where-Object { $_.Name -ne "WSearch" }
-        Write-Info "Outlook detected" "Keeping Windows Search Indexer"
-    }
+    # WSearch (Windows Search Indexer) is intentionally NOT in the bloat list:
+    # Start Menu search, File Explorer search, Outlook, Teams, and OneNote all
+    # depend on it, so disabling it degrades core UX for most users (see #20).
 
     # Context-aware: don't flag TabletInputService if touchscreen detected
     $hasTouchscreen = $false
@@ -310,7 +309,7 @@ function Get-SystemAnalysis {
     Write-Host "`n    -- Power Configuration --" -ForegroundColor Cyan
 
     $activePlan = powercfg /getactivescheme
-    $results.CurrentPowerPlan = if ($activePlan -match '"([^"]+)"') { $Matches[1] } else { "Unknown" }
+    $results.CurrentPowerPlan = Get-PowerPlanName (($activePlan | Out-String))
     Write-Info "Active Power Plan" $results.CurrentPowerPlan
 
     if ($results.CurrentPowerPlan -match "Balanced|Power saver") {
@@ -431,37 +430,51 @@ function Get-HealthScore {
         [hashtable]$AnalysisResults
     )
 
+    $r = $AnalysisResults
     $score = 100
 
-    if ($AnalysisResults.RAMUsedPct -gt 85)      { $score -= 15 }
-    elseif ($AnalysisResults.RAMUsedPct -gt 70)  { $score -= 5 }
+    # Read every input defensively: callers (e.g. the post-optimization
+    # re-score) may pass a hashtable that omits some keys, and StrictMode in
+    # a future refactor would otherwise turn a missing key into a crash.
+    $ramPct       = if ($r.ContainsKey('RAMUsedPct'))       { [double]$r.RAMUsedPct } else { 0 }
+    $tempMB       = if ($r.ContainsKey('TempSizeMB'))       { [double]$r.TempSizeMB } else { 0 }
+    $telemetry    = if ($r.ContainsKey('TelemetryEnabled')) { [bool]$r.TelemetryEnabled } else { $false }
+    $isLaptop     = if ($r.ContainsKey('IsLaptop'))         { [bool]$r.IsLaptop } else { $false }
+    $powerPlan    = if ($r.ContainsKey('CurrentPowerPlan')) { "$($r.CurrentPowerPlan)" } else { "" }
+    $visualFx     = if ($r.ContainsKey('VisualEffects'))    { "$($r.VisualEffects)" } else { "" }
+    $startupCount = if ($r.ContainsKey('StartupItems') -and $r.StartupItems) { @($r.StartupItems).Count } else { 0 }
+    $svcCount     = if ($r.ContainsKey('ServicesToDisable') -and $r.ServicesToDisable) { @($r.ServicesToDisable).Count } else { 0 }
+    $disks        = if ($r.ContainsKey('Disks') -and $r.Disks) { @($r.Disks) } else { @() }
 
-    $startupCount = $AnalysisResults.StartupItems.Count
-    if ($startupCount -gt 15)           { $score -= 15 }
-    elseif ($startupCount -gt 8)        { $score -= 8 }
+    if ($ramPct -gt 85)      { $score -= 15 }
+    elseif ($ramPct -gt 70)  { $score -= 5 }
 
-    if ($AnalysisResults.TempSizeMB -gt 500)     { $score -= 10 }
-    elseif ($AnalysisResults.TempSizeMB -gt 100) { $score -= 5 }
+    if ($startupCount -gt 15)    { $score -= 15 }
+    elseif ($startupCount -gt 8) { $score -= 8 }
 
-    if ($AnalysisResults.ServicesToDisable.Count -gt 5) { $score -= 10 }
-    elseif ($AnalysisResults.ServicesToDisable.Count -gt 0) { $score -= 5 }
+    if ($tempMB -gt 500)     { $score -= 10 }
+    elseif ($tempMB -gt 100) { $score -= 5 }
 
-    if ($AnalysisResults.TelemetryEnabled)       { $score -= 5 }
+    if ($svcCount -gt 5)     { $score -= 10 }
+    elseif ($svcCount -gt 0) { $score -= 5 }
+
+    if ($telemetry)          { $score -= 5 }
 
     # Balanced is the recommended plan on laptops (battery life, thermals);
     # only penalise non-performance plans on desktops.
-    if (-not $AnalysisResults.IsLaptop -and $AnalysisResults.CurrentPowerPlan -match "Balanced|Power saver") {
+    if (-not $isLaptop -and $powerPlan -match "Balanced|Power saver") {
         $score -= 10
     }
 
-    foreach ($d in $AnalysisResults.Disks) {
+    foreach ($d in $disks) {
         if ($d.Health -eq "CRITICAL") { $score -= 15 }
         elseif ($d.Health -eq "WARNING") { $score -= 8 }
     }
 
-    if ($AnalysisResults.VisualEffects -eq "Auto") { $score -= 5 }
+    if ($visualFx -eq "Auto") { $score -= 5 }
 
     return [math]::Max(0, [math]::Min(100, $score))
 }
 
-Export-ModuleMember -Function Get-SystemAnalysis, Get-HealthScore, Get-StartupItem
+Export-ModuleMember -Function Get-SystemAnalysis, Get-HealthScore, Get-StartupItem,
+    Get-SystemTier, Get-PowerPlanName

--- a/modules/Cleanup.psm1
+++ b/modules/Cleanup.psm1
@@ -17,6 +17,18 @@ function Clear-OldFile {
     [long]$freed = 0
     $cutoff = (Get-Date).AddHours(-$MinAgeHours)
 
+    # Resolve the base path and excludes to canonical (long) form. Enumerated
+    # file paths come back long, but $Path/$ExcludePaths may be passed in 8.3
+    # short form (e.g. C:\Users\RUNNER~1\...); without this the StartsWith
+    # exclusion silently misses and a protected file gets deleted.
+    try { $Path = (Get-Item -LiteralPath $Path -ErrorAction Stop).FullName } catch { $null = $_ }
+    $resolvedExcludes = @()
+    foreach ($ex in $ExcludePaths) {
+        if ([string]::IsNullOrWhiteSpace($ex)) { continue }
+        try { $resolvedExcludes += (Get-Item -LiteralPath $ex -ErrorAction Stop).FullName }
+        catch { $resolvedExcludes += $ex }
+    }
+
     $files = @()
     try {
         $files = Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction SilentlyContinue |
@@ -30,8 +42,8 @@ function Clear-OldFile {
 
     foreach ($f in $files) {
         $skip = $false
-        foreach ($ex in $ExcludePaths) {
-            if ($ex -and $f.FullName.StartsWith($ex, [System.StringComparison]::OrdinalIgnoreCase)) {
+        foreach ($ex in $resolvedExcludes) {
+            if ($f.FullName.StartsWith($ex, [System.StringComparison]::OrdinalIgnoreCase)) {
                 $skip = $true
                 break
             }

--- a/modules/Cleanup.psm1
+++ b/modules/Cleanup.psm1
@@ -1,5 +1,54 @@
 # Cleanup.psm1 - Temp files, disk cleanup, recycle bin
 
+function Clear-OldFile {
+    # Delete files under $Path that are older than $MinAgeHours, one file at a
+    # time. Per-file deletion (instead of a recursive Remove-Item) means a
+    # locked or in-use file - e.g. an installer/CBS file Windows is actively
+    # writing during an update - is skipped rather than aborting the whole
+    # sweep or wedging servicing. Skips reparse points (junctions/symlinks) so
+    # we never follow a link out of the intended directory. Returns the number
+    # of bytes actually freed, so the caller's total is accurate.
+    param(
+        [string]$Path,
+        [int]$MinAgeHours = 24,
+        [string[]]$ExcludePaths = @()
+    )
+
+    [long]$freed = 0
+    $cutoff = (Get-Date).AddHours(-$MinAgeHours)
+
+    $files = @()
+    try {
+        $files = Get-ChildItem -LiteralPath $Path -Recurse -Force -File -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.LastWriteTime -lt $cutoff -and
+                -not ($_.Attributes -band [System.IO.FileAttributes]::ReparsePoint)
+            }
+    } catch {
+        return [long]0
+    }
+
+    foreach ($f in $files) {
+        $skip = $false
+        foreach ($ex in $ExcludePaths) {
+            if ($ex -and $f.FullName.StartsWith($ex, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $skip = $true
+                break
+            }
+        }
+        if ($skip) { continue }
+
+        $size = $f.Length
+        try {
+            Remove-Item -LiteralPath $f.FullName -Force -ErrorAction Stop
+            $freed += $size
+        } catch {
+            $null = $_  # locked / in use - leave it in place
+        }
+    }
+    return $freed
+}
+
 function Invoke-CleanupOptimization {
     param([hashtable]$Analysis)
 
@@ -19,25 +68,29 @@ function Invoke-CleanupOptimization {
         @{ Path = "$env:WINDIR\Minidump";                                          Desc = "Minidump Files" }
     )
 
+    # Never delete the optimizer's own log/undo files if its data dir happens
+    # to live under one of the temp paths (e.g. the %TEMP% fallback).
+    $excludes = @()
+    if (Get-Command Get-OptimizerDataDir -ErrorAction SilentlyContinue) {
+        $excludes += (Get-OptimizerDataDir)
+    }
+
+    # Only touch files older than this. Disk Cleanup uses the same idea:
+    # freshly written temp files are likely still in use by a running app.
+    $minAgeHours = 24
+
     $totalCleaned = 0
     foreach ($cp in $cleanPaths) {
         if (Test-Path $cp.Path) {
             if ($DryRun) {
-                Write-Dry "Would clean $($cp.Desc) at $($cp.Path)"
+                Write-Dry "Would clean files older than ${minAgeHours}h in $($cp.Desc) at $($cp.Path)"
                 continue
             }
-            try {
-                $before = (Get-ChildItem $cp.Path -Recurse -Force -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum
-                Get-ChildItem $cp.Path -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
-                $after = (Get-ChildItem $cp.Path -Recurse -Force -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum
-                $freed = [math]::Round(($before - $after) / 1MB, 1)
-                if ($freed -gt 0) {
-                    Write-Fix "Cleaned $($cp.Desc): $freed MB freed"
-                    $totalCleaned += $freed
-                }
-            } catch {
-                Write-Skip "Could not clean $($cp.Desc)"
-                Log "[ERROR] Cleanup failed for $($cp.Path): $_"
+            $freedBytes = Clear-OldFile -Path $cp.Path -MinAgeHours $minAgeHours -ExcludePaths $excludes
+            $freed = [math]::Round($freedBytes / 1MB, 1)
+            if ($freed -gt 0) {
+                Write-Fix "Cleaned $($cp.Desc): $freed MB freed"
+                $totalCleaned += $freed
             }
         }
     }
@@ -97,4 +150,4 @@ function Invoke-CleanupOptimization {
     }
 }
 
-Export-ModuleMember -Function Invoke-CleanupOptimization
+Export-ModuleMember -Function Invoke-CleanupOptimization, Clear-OldFile

--- a/modules/Config.psm1
+++ b/modules/Config.psm1
@@ -13,7 +13,6 @@ $script:BloatServiceDefinitions = @(
     @{ Name = "DiagTrack";                  Desc = "Connected User Experience & Telemetry" },
     @{ Name = "dmwappushservice";           Desc = "WAP Push Message Routing" },
     @{ Name = "SysMain";                    Desc = "Superfetch (can hurt SSDs)" },
-    @{ Name = "WSearch";                    Desc = "Windows Search Indexer" },
     @{ Name = "XblAuthManager";             Desc = "Xbox Live Auth Manager" },
     @{ Name = "XblGameSave";               Desc = "Xbox Live Game Save" },
     @{ Name = "XboxGipSvc";                Desc = "Xbox Accessory Management" },
@@ -51,6 +50,71 @@ $script:FeaturesToDisable = @(
     "Printing-Foundation-Features",
     "FaxServicesClientPackage"
 )
+
+# Named optimization presets. Each maps to a curated set of sections so a
+# user can pick an intent ("just privacy", "tune for games") instead of
+# hand-listing sections. "Balanced" is every section (the default run).
+# A preset composes with -Skip; -Only still overrides a preset entirely.
+$script:OptimizationPresets = [ordered]@{
+    Balanced = $script:ValidSections
+    Gaming   = @("Cleanup", "Power", "VisualEffects", "Network", "Performance",
+                 "SSD", "Memory", "ScheduledTasks", "Boot", "Disk", "BackgroundApps")
+    Privacy  = @("Privacy", "Services", "Notifications", "BackgroundApps",
+                 "ScheduledTasks", "Security")
+    Minimal  = @("Cleanup", "Privacy")
+}
+
+function Get-PresetNameList {
+    return @($script:OptimizationPresets.Keys)
+}
+
+function Test-PresetName {
+    param([string]$Name)
+    if ([string]::IsNullOrWhiteSpace($Name)) { return $false }
+    return @($script:OptimizationPresets.Keys) -contains $Name
+}
+
+function Get-PresetSection {
+    param([string]$Name)
+    if (-not (Test-PresetName $Name)) { return @() }
+    return @($script:OptimizationPresets[$Name])
+}
+
+function Resolve-EnabledSection {
+    # Compute the final, canonically-ordered list of sections to run from a
+    # preset plus -Only/-Skip. -Only wins outright; otherwise the preset
+    # (or all sections) is the base, with -Skip removed.
+    param(
+        [string]$PresetName,
+        [string[]]$Only,
+        [string[]]$Skip
+    )
+
+    $all = $script:ValidSections
+    if ($Only -and $Only.Count -gt 0) {
+        $base = $all | Where-Object { $_ -in $Only }
+    } elseif ($PresetName -and (Test-PresetName $PresetName)) {
+        $presetSections = Get-PresetSection -Name $PresetName
+        $base = $all | Where-Object { $_ -in $presetSections }
+    } else {
+        $base = $all
+    }
+
+    if ($Skip -and $Skip.Count -gt 0) {
+        $base = $base | Where-Object { $_ -notin $Skip }
+    }
+    return @($base)
+}
+
+function Get-OSBuildNumber {
+    # Parse a Win32_OperatingSystem build string into an int. Returns 0 if
+    # the build is empty/non-numeric (e.g. when hardware detection failed
+    # and left OSBuild blank), so callers can compare without [int] throwing.
+    param($Build)
+    $n = 0
+    [void][int]::TryParse("$Build", [ref]$n)
+    return $n
+}
 
 # DryRun state - set by the entry point
 $script:DryRunMode = $false
@@ -110,6 +174,13 @@ $script:AllowedRegHives = @(
     'HKCU:\', 'HKLM:\', 'HKCR:\', 'HKU:\', 'HKCC:\'
 )
 
+# Registry value kinds the undo system knows how to capture and restore.
+# Reject anything else so a typo in a caller can't write a value the undo
+# file then fails to roll back.
+$script:AllowedRegTypes = @(
+    'String', 'ExpandString', 'Binary', 'DWord', 'MultiString', 'QWord'
+)
+
 function Test-RegPathAllowed {
     [CmdletBinding()]
     param([string]$Path)
@@ -135,6 +206,13 @@ function Set-RegValue {
     if (-not (Test-RegPathAllowed -Path $Path)) {
         if (Get-Command Log -ErrorAction SilentlyContinue) {
             Log "[ERROR] Rejected registry path '$Path' - must start with one of: $($script:AllowedRegHives -join ', ')"
+        }
+        return $false
+    }
+
+    if ($Type -notin $script:AllowedRegTypes) {
+        if (Get-Command Log -ErrorAction SilentlyContinue) {
+            Log "[ERROR] Rejected registry type '$Type' for $Path\$Name - must be one of: $($script:AllowedRegTypes -join ', ')"
         }
         return $false
     }
@@ -191,4 +269,6 @@ function Test-SectionEnabled {
 
 Export-ModuleMember -Function Set-RegValue, Get-ValidSectionList, Get-BloatServiceDefinition,
     Get-BloatScheduledTaskList, Get-FeaturesToDisable, Test-SectionEnabled,
-    Set-DryRunMode, Get-DryRunMode, Get-OptimizerDataDir, Test-RegPathAllowed
+    Set-DryRunMode, Get-DryRunMode, Get-OptimizerDataDir, Test-RegPathAllowed,
+    Get-PresetNameList, Test-PresetName, Get-PresetSection, Resolve-EnabledSection,
+    Get-OSBuildNumber

--- a/modules/Explorer.psm1
+++ b/modules/Explorer.psm1
@@ -34,12 +34,17 @@ function Invoke-ContextMenuOptimization {
 
     $isDry = Get-DryRunMode
 
-    if ([int]$Analysis.OSBuild -ge 22000) {
-        $ctxPath = "HKCU:\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}\InprocServer32"
+    if ((Get-OSBuildNumber $Analysis.OSBuild) -ge 22000) {
+        # The classic menu is triggered by the mere presence of this CLSID
+        # key, so record the key for undo (Save-RegistryKeyState removes a
+        # key we created on rollback - value-level undo can't).
+        $clsidKey = "HKCU:\Software\Classes\CLSID\{86ca1aa0-34aa-4e8b-a509-50c905bae2a2}"
+        $ctxPath  = "$clsidKey\InprocServer32"
         if ($isDry) {
             Write-Dry "Would restore classic right-click context menu"
         } else {
             try {
+                Save-RegistryKeyState -Path $clsidKey
                 if (-not (Test-Path $ctxPath)) { New-Item -Path $ctxPath -Force | Out-Null }
                 Set-ItemProperty -Path $ctxPath -Name "(Default)" -Value "" -Force
                 Write-Fix "Classic right-click context menu restored (Windows 11)"
@@ -48,9 +53,9 @@ function Invoke-ContextMenuOptimization {
                 Log "[ERROR] Context menu restore: $_"
             }
         }
+    } else {
+        Write-Skip "Classic context menu tweak skipped (Windows 11 only)"
     }
-
-    if (-not $isDry) { Write-Fix "Context menu cleaned" }
 }
 
 Export-ModuleMember -Function Invoke-ExplorerOptimization, Invoke-ContextMenuOptimization

--- a/modules/Network.psm1
+++ b/modules/Network.psm1
@@ -37,7 +37,7 @@ function Invoke-NetworkOptimization {
     }
 
     if ($applied -gt 0) {
-        Write-Fix "Nagle's algorithm disabled on $applied physical adapter(s)"
+        if (-not $DryRun) { Write-Fix "Nagle's algorithm disabled on $applied physical adapter(s)" }
     } else {
         Write-Skip "No eligible physical adapters; skipped Nagle tuning"
     }
@@ -48,7 +48,7 @@ function Invoke-NetworkOptimization {
     # guidance is 10-20%. 10 keeps gaming/network priority high without
     # crippling background work.
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "SystemResponsiveness" 10
-    Write-Fix "Network throttling disabled (SystemResponsiveness=10)"
+    if (-not $DryRun) { Write-Fix "Network throttling disabled (SystemResponsiveness=10)" }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxCacheTtl" 86400
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxNegativeCacheTtl" 5
@@ -65,8 +65,14 @@ function Invoke-NetworkOptimization {
         }
 
         netsh int tcp set global autotuninglevel=normal 2>&1 | Out-Null
+        $autotuneOk = ($LASTEXITCODE -eq 0)
         netsh int tcp set global ecncapability=enabled 2>&1 | Out-Null
-        Write-Fix "TCP auto-tuning and ECN optimized"
+        $ecnOk = ($LASTEXITCODE -eq 0)
+        if ($autotuneOk -and $ecnOk) {
+            Write-Fix "TCP auto-tuning and ECN optimized"
+        } else {
+            Write-Skip "Some TCP global settings could not be applied (netsh reported an error)"
+        }
     }
 }
 

--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -51,9 +51,9 @@ function Invoke-PowerOptimization {
 
         # PowerThrottling key was added in 1903 (build 18362); writing it on
         # earlier builds creates a key Windows ignores while we report success.
-        if ([int]$Analysis.OSBuild -ge 18362) {
+        if ((Get-OSBuildNumber $Analysis.OSBuild) -ge 18362) {
             Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" "PowerThrottlingOff" 1
-            Write-Fix "Disabled power throttling"
+            if (-not $DryRun) { Write-Fix "Disabled power throttling" }
         } else {
             Write-Skip "Power throttling tweak skipped (requires Windows 10 1903 or newer)"
         }
@@ -65,6 +65,8 @@ function Invoke-PowerOptimization {
 
 function Invoke-VisualEffectsOptimization {
     param([hashtable]$Analysis)
+
+    $DryRun = Get-DryRunMode
 
     Write-Host "`n    -- Visual Effects Optimization --" -ForegroundColor Cyan
 
@@ -81,7 +83,7 @@ function Invoke-VisualEffectsOptimization {
         Set-RegValue $advPath "TaskbarAnimations" 0
         Set-RegValue $dwmPath "EnableAeroPeek" 0
         Set-RegValue "HKCU:\Control Panel\Desktop" "DragFullWindows" "0" "String"
-        Write-Fix "Visual effects set to MAXIMUM PERFORMANCE (Low-End system)"
+        if (-not $DryRun) { Write-Fix "Visual effects set to MAXIMUM PERFORMANCE (Low-End system)" }
     } elseif ($Analysis.SystemTier -eq "Mid-Range") {
         Set-RegValue $vePath "VisualFXSetting" 3
         Set-RegValue "HKCU:\Control Panel\Desktop" "FontSmoothing" "2" "String"
@@ -90,48 +92,50 @@ function Invoke-VisualEffectsOptimization {
         Set-RegValue $advPath "TaskbarAnimations" 0
         Set-RegValue $dwmPath "EnableAeroPeek" 0
         Set-RegValue "HKCU:\Control Panel\Desktop" "DragFullWindows" "1" "String"
-        Write-Fix "Visual effects optimized for balanced quality/performance"
+        if (-not $DryRun) { Write-Fix "Visual effects optimized for balanced quality/performance" }
     } else {
         Set-RegValue "HKCU:\Control Panel\Desktop\WindowMetrics" "MinAnimate" "0" "String"
         Set-RegValue $advPath "TaskbarAnimations" 0
-        Write-Fix "Visual effects: minimal tweaks (High-End system - keeping quality)"
+        if (-not $DryRun) { Write-Fix "Visual effects: minimal tweaks (High-End system - keeping quality)" }
     }
 }
 
 function Invoke-PerformanceOptimization {
     param([hashtable]$Analysis)
 
+    $DryRun = Get-DryRunMode
+
     Write-Host "`n    -- Performance Tweaks --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\GameBar" "AllowAutoGameMode" 1
     Set-RegValue "HKCU:\Software\Microsoft\GameBar" "AutoGameModeEnabled" 1
-    Write-Fix "Game Mode enabled"
+    if (-not $DryRun) { Write-Fix "Game Mode enabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\GameDVR" "AppCaptureEnabled" 0
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_Enabled" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" "AllowGameDVR" 0
-    Write-Fix "Game Bar / DVR capture disabled (reduces overhead)"
+    if (-not $DryRun) { Write-Fix "Game Bar / DVR capture disabled (reduces overhead)" }
 
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_FSEBehaviorMode" 2
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_HonorUserFSEBehaviorMode" 1
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_FSEBehavior" 2
-    Write-Fix "Fullscreen optimizations configured"
+    if (-not $DryRun) { Write-Fix "Fullscreen optimizations configured" }
 
-    if ([int]$Analysis.OSBuild -ge 19041) {
+    if ((Get-OSBuildNumber $Analysis.OSBuild) -ge 19041) {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" "HwSchMode" 2
-        Write-Fix "Hardware-accelerated GPU scheduling enabled"
+        if (-not $DryRun) { Write-Fix "Hardware-accelerated GPU scheduling enabled" }
     }
 
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseSpeed" "0" "String"
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseThreshold1" "0" "String"
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseThreshold2" "0" "String"
-    Write-Fix "Mouse acceleration disabled (1:1 precision)"
+    if (-not $DryRun) { Write-Fix "Mouse acceleration disabled (1:1 precision)" }
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "GPU Priority" 8
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "Priority" 6
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "Scheduling Category" "High" "String"
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "SFIO Priority" "High" "String"
-    Write-Fix "Multimedia scheduler optimized for games"
+    if (-not $DryRun) { Write-Fix "Multimedia scheduler optimized for games" }
 }
 
 function Invoke-SSDOptimization {
@@ -148,10 +152,10 @@ function Invoke-SSDOptimization {
     # disables a useful cache for any HDD also present in the system and
     # buys nothing on the SSD. Only apply the disable on older builds
     # where the OS still treats every drive the same.
-    if ([int]$Analysis.OSBuild -lt 17763) {
+    if ((Get-OSBuildNumber $Analysis.OSBuild) -lt 17763) {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnablePrefetcher" 0
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnableSuperfetch" 0
-        Write-Fix "Prefetch/Superfetch disabled (legacy build, SSD doesn't need it)"
+        if (-not $DryRun) { Write-Fix "Prefetch/Superfetch disabled (legacy build, SSD doesn't need it)" }
     } else {
         Write-Skip "Prefetch/Superfetch left to Windows (1809+ adapts per drive type)"
     }
@@ -161,10 +165,18 @@ function Invoke-SSDOptimization {
         Write-Dry "Would enable TRIM for SSD"
     } else {
         fsutil behavior set disablelastaccess 1 2>&1 | Out-Null
-        Write-Fix "Last access timestamps disabled (reduces SSD writes)"
+        if ($LASTEXITCODE -eq 0) {
+            Write-Fix "Last access timestamps disabled (reduces SSD writes)"
+        } else {
+            Write-Skip "Could not change last-access behavior (fsutil exit $LASTEXITCODE)"
+        }
 
         fsutil behavior set disabledeletenotify 0 2>&1 | Out-Null
-        Write-Fix "TRIM enabled for SSD"
+        if ($LASTEXITCODE -eq 0) {
+            Write-Fix "TRIM enabled for SSD"
+        } else {
+            Write-Skip "Could not enable TRIM (fsutil exit $LASTEXITCODE)"
+        }
     }
 
     Write-Good "SSD optimization complete"
@@ -207,8 +219,11 @@ function Invoke-MemoryOptimization {
         }
     }
 
-    Set-RegValue "HKLM:\SYSTEM\ControlSet001\Services\Ndu" "Start" 4
-    Write-Fix "NDU service disabled (prevents memory leak)"
+    # CurrentControlSet, not ControlSet001: the active control set is not
+    # always 001 (it can be 002+ after a restore or failed boot), so a
+    # hardcoded 001 may edit a non-active set and silently no-op.
+    Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Ndu" "Start" 4
+    if (-not $DryRun) { Write-Fix "NDU service disabled (prevents memory leak)" }
 }
 
 function Invoke-ScheduledTasksOptimization {
@@ -232,6 +247,7 @@ function Invoke-ScheduledTasksOptimization {
             $taskName = Split-Path $task -Leaf
             $t = Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue
             if ($t -and $t.State -ne 'Disabled') {
+                Save-ScheduledTaskState -TaskPath $t.TaskPath -TaskName $t.TaskName
                 Disable-ScheduledTask -TaskPath $t.TaskPath -TaskName $t.TaskName -ErrorAction Stop | Out-Null
                 $shortName = $task.Split('\')[-1]
                 Write-Fix "Disabled task: $shortName"
@@ -242,6 +258,40 @@ function Invoke-ScheduledTasksOptimization {
     }
 }
 
+function Test-DualBootSystem {
+    # Heuristic dual-boot detection: more than one "Windows Boot Loader"
+    # entry, or a firmware entry pointing at a non-Microsoft EFI loader
+    # (grub/shim/etc.), means another OS shares this machine.
+    try {
+        $enum = bcdedit /enum all 2>$null
+        if (-not $enum) { return $false }
+        $text = $enum -join "`n"
+        if (([regex]::Matches($text, 'Windows Boot Loader')).Count -gt 1) { return $true }
+        foreach ($line in $enum) {
+            if ($line -match '\\EFI\\' -and $line -notmatch '\\EFI\\Microsoft\\') {
+                return $true
+            }
+        }
+    } catch {
+        $null = $_
+    }
+    return $false
+}
+
+function Test-HibernationAvailable {
+    # Fast Startup relies on hibernation. If it's off, HiberbootEnabled is
+    # inert, so we shouldn't report enabling it as a real fix.
+    foreach ($name in @('HibernateEnabled', 'HibernateEnabledDefault')) {
+        try {
+            $p = Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Power' -Name $name -ErrorAction SilentlyContinue
+            if ($null -ne $p -and $p.$name -eq 1) { return $true }
+        } catch {
+            $null = $_
+        }
+    }
+    return $false
+}
+
 function Invoke-BootOptimization {
     param([hashtable]$Analysis)
 
@@ -250,35 +300,53 @@ function Invoke-BootOptimization {
 
     Write-Host "`n    -- Boot Optimization --" -ForegroundColor Cyan
 
-    Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" "HiberbootEnabled" 1
-    Write-Fix "Fast Startup enabled"
+    # Fast Startup (HiberbootEnabled) hibernates the kernel session on
+    # shutdown. On dual-boot machines this leaves NTFS volumes locked in a
+    # hibernated state that another OS can corrupt, and it blocks clean
+    # external-drive ejection. Skip it when a second OS is present, and only
+    # claim success when hibernation is actually available.
+    if (Test-DualBootSystem) {
+        Write-Skip "Fast Startup skipped (dual-boot detected - prevents NTFS corruption)"
+    } elseif (-not (Test-HibernationAvailable)) {
+        Write-Skip "Fast Startup skipped (hibernation unavailable - run 'powercfg /hibernate on' first)"
+    } else {
+        Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" "HiberbootEnabled" 1
+        if (-not $DryRun) { Write-Fix "Fast Startup enabled" }
+    }
 
     if ($DryRun) {
         Write-Dry "Would reduce boot menu timeout to 3 seconds"
     } else {
+        Save-BcdTimeout
         bcdedit /timeout 3 2>&1 | Out-Null
-        Write-Fix "Boot menu timeout reduced to 3 seconds"
+        if ($LASTEXITCODE -eq 0) {
+            Write-Fix "Boot menu timeout reduced to 3 seconds"
+        } else {
+            Write-Skip "Could not change boot timeout (bcdedit exit $LASTEXITCODE)"
+        }
     }
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" "VerboseStatus" 1
-    Write-Fix "Verbose boot messages enabled"
+    if (-not $DryRun) { Write-Fix "Verbose boot messages enabled" }
 }
 
 function Invoke-BackgroundAppsOptimization {
     param([hashtable]$Analysis)
 
     $null = $Analysis  # Used for interface consistency
+    $DryRun = Get-DryRunMode
     Write-Host "`n    -- Background Apps --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" "GlobalUserDisabled" 1
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" "BackgroundAppGlobalToggle" 0
-    Write-Fix "Background apps disabled globally (saves CPU & RAM)"
+    if (-not $DryRun) { Write-Fix "Background apps disabled globally (saves CPU & RAM)" }
 }
 
 function Invoke-NotificationsOptimization {
     param([hashtable]$Analysis)
 
     $null = $Analysis  # Used for interface consistency
+    $DryRun = Get-DryRunMode
     Write-Host "`n    -- Notification & Distraction Cleanup --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "RotatingLockScreenOverlayEnabled" 0
@@ -286,7 +354,7 @@ function Invoke-NotificationsOptimization {
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement" "ScoobeSystemSettingEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-310093Enabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Notifications\Settings" "NOC_GLOBAL_SETTING_ALLOW_TOASTS_ABOVE_LOCK" 0
-    Write-Fix "Notifications and nag screens reduced"
+    if (-not $DryRun) { Write-Fix "Notifications and nag screens reduced" }
 }
 
 function Invoke-DiskOptimization {
@@ -389,6 +457,7 @@ function Invoke-FeaturesOptimization {
         try {
             $f = Get-WindowsOptionalFeature -Online -FeatureName $feat -ErrorAction SilentlyContinue
             if ($f -and $f.State -eq 'Enabled') {
+                Save-FeatureState -FeatureName $feat
                 Disable-WindowsOptionalFeature -Online -FeatureName $feat -NoRestart -ErrorAction Stop | Out-Null
                 Write-Fix "Disabled feature: $feat"
             }

--- a/modules/Privacy.psm1
+++ b/modules/Privacy.psm1
@@ -4,35 +4,36 @@ function Invoke-PrivacyOptimization {
     param([hashtable]$Analysis)
 
     $null = $Analysis  # Used for interface consistency
+    $DryRun = Get-DryRunMode
     Write-Host "`n    -- Privacy & Telemetry Hardening --" -ForegroundColor Cyan
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" "AllowTelemetry" 0
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" "AllowTelemetry" 0
-    Write-Fix "Telemetry disabled"
+    if (-not $DryRun) { Write-Fix "Telemetry disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" "AllowCortana" 0
-    Write-Fix "Cortana disabled"
+    if (-not $DryRun) { Write-Fix "Cortana disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo" "Enabled" 0
-    Write-Fix "Advertising ID disabled"
+    if (-not $DryRun) { Write-Fix "Advertising ID disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "EnableActivityFeed" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "PublishUserActivities" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "UploadUserActivities" 0
-    Write-Fix "Activity History disabled"
+    if (-not $DryRun) { Write-Fix "Activity History disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" "DisableLocation" 1
-    Write-Fix "Location tracking disabled"
+    if (-not $DryRun) { Write-Fix "Location tracking disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Siuf\Rules" "NumberOfSIUFInPeriod" 0
     Set-RegValue "HKCU:\Software\Microsoft\Siuf\Rules" "PeriodInNanoSeconds" 0
-    Write-Fix "Feedback requests disabled"
+    if (-not $DryRun) { Write-Fix "Feedback requests disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "Start_TrackProgs" 0
-    Write-Fix "App launch tracking disabled"
+    if (-not $DryRun) { Write-Fix "App launch tracking disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Privacy" "TailoredExperiencesWithDiagnosticDataEnabled" 0
-    Write-Fix "Tailored experiences disabled"
+    if (-not $DryRun) { Write-Fix "Tailored experiences disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338389Enabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-310093Enabled" 0
@@ -40,7 +41,7 @@ function Invoke-PrivacyOptimization {
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SilentInstalledAppsEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SystemPaneSuggestionsEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SoftLandingEnabled" 0
-    Write-Fix "Tips, suggestions, and silent app installs disabled"
+    if (-not $DryRun) { Write-Fix "Tips, suggestions, and silent app installs disabled" }
 }
 
 Export-ModuleMember -Function Invoke-PrivacyOptimization

--- a/modules/Security.psm1
+++ b/modules/Security.psm1
@@ -30,14 +30,14 @@ function Invoke-SecurityOptimization {
         Write-Warn "Active RDP session detected - skipping Remote Desktop disable"
     } else {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" "fDenyTSConnections" 1
-        Write-Fix "Remote Desktop disabled (security)"
+        if (-not $DryRun) { Write-Fix "Remote Desktop disabled (security)" }
     }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Remote Assistance" "fAllowToGetHelp" 0
-    Write-Fix "Remote Assistance disabled"
+    if (-not $DryRun) { Write-Fix "Remote Assistance disabled" }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" "SMB1" 0
-    Write-Fix "SMBv1 disabled (security)"
+    if (-not $DryRun) { Write-Fix "SMBv1 disabled (security)" }
 
     if ($DryRun) {
         Write-Dry "Would verify Windows Firewall is enabled"
@@ -52,7 +52,7 @@ function Invoke-SecurityOptimization {
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" "NoDriveTypeAutoRun" 255
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers" "DisableAutoplay" 1
-    Write-Fix "AutoRun/AutoPlay disabled (prevents USB malware)"
+    if (-not $DryRun) { Write-Fix "AutoRun/AutoPlay disabled (prevents USB malware)" }
 }
 
 Export-ModuleMember -Function Invoke-SecurityOptimization

--- a/modules/Services.psm1
+++ b/modules/Services.psm1
@@ -14,6 +14,7 @@ function Invoke-ServicesOptimization {
                 continue
             }
             try {
+                Save-ServiceState -Name $svc.Name
                 Stop-Service -Name $svc.Name -Force -ErrorAction Stop
                 Set-Service -Name $svc.Name -StartupType Disabled -ErrorAction Stop
                 Write-Fix "Disabled: $($svc.Desc)"

--- a/modules/UI.psm1
+++ b/modules/UI.psm1
@@ -8,7 +8,7 @@ function Write-Banner {
 
     ============================================================
     |     ULTIMATE WINDOWS SYSTEM OPTIMIZER                    |
-    |         Smart Analysis & Tuning Engine v3.1              |
+    |         Smart Analysis & Tuning Engine v4.0              |
     ============================================================
 
 "@

--- a/modules/UndoManager.psm1
+++ b/modules/UndoManager.psm1
@@ -1,6 +1,14 @@
-# UndoManager.psm1 - Save and restore registry state for rollback
+# UndoManager.psm1 - Capture and restore system state for rollback.
+# Covers registry values plus non-registry changes (services, scheduled
+# tasks, optional features, boot timeout) so the undo file can reverse
+# everything the optimizer modifies, not just the registry.
 
 $script:UndoEntries = [System.Collections.Generic.List[hashtable]]::new()
+# De-dup guard: the same registry value or service can be touched by more
+# than one section in a single run. We only want to record the FIRST-seen
+# pre-run state, otherwise a later capture stores an already-modified value
+# as the "original" and rollback reverts to an intermediate state.
+$script:SeenKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 
 function Save-RegistryState {
     param(
@@ -10,7 +18,11 @@ function Save-RegistryState {
         [string]$Type = "DWord"
     )
 
+    $key = "REG|$Path|$Name"
+    if ($script:SeenKeys.Contains($key)) { return }
+
     $entry = @{
+        Kind     = 'Registry'
         Path     = $Path
         Name     = $Name
         NewValue = $NewValue
@@ -32,6 +44,102 @@ function Save-RegistryState {
     }
 
     $script:UndoEntries.Add($entry)
+    [void]$script:SeenKeys.Add($key)
+}
+
+function Save-ServiceState {
+    # Record a service's startup type and running state before it is
+    # stopped/disabled so the undo file can put it back.
+    param([string]$Name)
+
+    $key = "SVC|$Name"
+    if ($script:SeenKeys.Contains($key)) { return }
+
+    $svc = Get-Service -Name $Name -ErrorAction SilentlyContinue
+    if (-not $svc) { return }
+
+    $script:UndoEntries.Add(@{
+        Kind         = 'Service'
+        Name         = $Name
+        OldStartType = "$($svc.StartType)"
+        WasRunning   = ($svc.Status -eq 'Running')
+    })
+    [void]$script:SeenKeys.Add($key)
+}
+
+function Save-ScheduledTaskState {
+    # We only ever disable tasks that are currently enabled, so restoring
+    # simply means re-enabling. Record identity for that.
+    param([string]$TaskPath, [string]$TaskName)
+
+    $key = "TASK|$TaskPath|$TaskName"
+    if ($script:SeenKeys.Contains($key)) { return }
+
+    $script:UndoEntries.Add(@{
+        Kind     = 'ScheduledTask'
+        TaskPath = $TaskPath
+        TaskName = $TaskName
+    })
+    [void]$script:SeenKeys.Add($key)
+}
+
+function Save-FeatureState {
+    # Optional features are only disabled when currently Enabled, so restore
+    # re-enables them.
+    param([string]$FeatureName)
+
+    $key = "FEAT|$FeatureName"
+    if ($script:SeenKeys.Contains($key)) { return }
+
+    $script:UndoEntries.Add(@{
+        Kind        = 'Feature'
+        FeatureName = $FeatureName
+    })
+    [void]$script:SeenKeys.Add($key)
+}
+
+function Save-BcdTimeout {
+    # Capture the current boot menu timeout before bcdedit changes it.
+    # bcdedit output is best-effort to parse; default to the Windows
+    # standard of 30 seconds if the value can't be read.
+    $key = "BCD|timeout"
+    if ($script:SeenKeys.Contains($key)) { return }
+
+    $old = 30
+    try {
+        $out = bcdedit /enum '{bootmgr}' 2>$null
+        $line = $out | Where-Object { $_ -match '^\s*timeout\s+\d+' } | Select-Object -First 1
+        if ($line -and $line -match '(\d+)\s*$') { $old = [int]$Matches[1] }
+    } catch {
+        $null = $_
+    }
+
+    $script:UndoEntries.Add(@{
+        Kind       = 'BcdTimeout'
+        OldTimeout = $old
+    })
+    [void]$script:SeenKeys.Add($key)
+}
+
+function Save-RegistryKeyState {
+    # Record whether a registry KEY existed before we created it. Some tweaks
+    # work purely by a key's presence (e.g. the Windows 11 classic context
+    # menu), and value-level undo can't delete a key - so undo needs to know
+    # to remove a key we added wholesale.
+    param([string]$Path)
+
+    $key = "REGKEY|$Path"
+    if ($script:SeenKeys.Contains($key)) { return }
+
+    $existed = $false
+    try { $existed = [bool](Test-Path -LiteralPath $Path) } catch { $null = $_ }
+
+    $script:UndoEntries.Add(@{
+        Kind    = 'RegistryKey'
+        Path    = $Path
+        Existed = $existed
+    })
+    [void]$script:SeenKeys.Add($key)
 }
 
 function Export-UndoFile {
@@ -54,17 +162,27 @@ function Export-UndoFile {
     $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
     $filePath = Join-Path $OutputDir "undo_$timestamp.json"
 
-    # Convert to serializable format
+    # Convert to a serializable format. Registry entries Base64-encode any
+    # byte[] values; non-registry entries are already JSON-friendly scalars.
     $exportData = @()
     foreach ($e in $script:UndoEntries) {
-        $exportData += @{
-            Path     = $e.Path
-            Name     = $e.Name
-            NewValue = if ($e.NewValue -is [byte[]]) { [Convert]::ToBase64String($e.NewValue) } else { $e.NewValue }
-            Type     = $e.Type
-            OldValue = if ($e.OldValue -is [byte[]]) { [Convert]::ToBase64String($e.OldValue) } else { $e.OldValue }
-            Existed  = $e.Existed
-            IsBase64 = ($e.OldValue -is [byte[]] -or $e.NewValue -is [byte[]])
+        $kind = if ($e.ContainsKey('Kind')) { $e.Kind } else { 'Registry' }
+        if ($kind -eq 'Registry') {
+            $exportData += @{
+                Kind     = 'Registry'
+                Path     = $e.Path
+                Name     = $e.Name
+                NewValue = if ($e.NewValue -is [byte[]]) { [Convert]::ToBase64String($e.NewValue) } else { $e.NewValue }
+                Type     = $e.Type
+                OldValue = if ($e.OldValue -is [byte[]]) { [Convert]::ToBase64String($e.OldValue) } else { $e.OldValue }
+                Existed  = $e.Existed
+                IsBase64 = ($e.OldValue -is [byte[]] -or $e.NewValue -is [byte[]])
+            }
+        } else {
+            # Clone the action entry verbatim - all fields are scalars.
+            $copy = @{}
+            foreach ($k in $e.Keys) { $copy[$k] = $e[$k] }
+            $exportData += $copy
         }
     }
 
@@ -106,43 +224,118 @@ function Set-UndoFileAcl {
     }
 }
 
+function Get-UndoFileList {
+    # Return undo_*.json files in a directory, newest first. Used by the
+    # entry point for -Undo Latest and -ListUndo.
+    param([string]$Directory)
+
+    if ([string]::IsNullOrWhiteSpace($Directory)) {
+        if (Get-Command Get-OptimizerDataDir -ErrorAction SilentlyContinue) {
+            $Directory = Get-OptimizerDataDir
+        } else {
+            $Directory = $env:TEMP
+        }
+    }
+
+    if (-not (Test-Path -LiteralPath $Directory)) { return @() }
+    return @(Get-ChildItem -LiteralPath $Directory -Filter 'undo_*.json' -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTime -Descending)
+}
+
 function Restore-FromUndoFile {
     param(
         [string]$FilePath
     )
 
-    if (-not (Test-Path $FilePath)) {
-        Write-Error "Undo file not found: $FilePath"
+    if ([string]::IsNullOrWhiteSpace($FilePath) -or -not (Test-Path -LiteralPath $FilePath)) {
+        Write-Warning "Undo file not found: $FilePath"
         return $false
     }
 
-    $entries = Get-Content -Path $FilePath -Raw | ConvertFrom-Json
+    # A truncated or hand-edited undo file should fail cleanly, not throw an
+    # unhandled parse error.
+    try {
+        $raw = Get-Content -LiteralPath $FilePath -Raw -ErrorAction Stop
+        $entries = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Warning "Undo file is not valid JSON: $FilePath"
+        return $false
+    }
+
+    # A single-entry file deserializes to one object, not an array.
+    $entries = @($entries)
+    if ($entries.Count -eq 0) {
+        Write-Warning "Undo file contains no entries: $FilePath"
+        return $false
+    }
+
     $restored = 0
     $failed = 0
 
     foreach ($entry in $entries) {
+        $kind = if ($entry.PSObject.Properties['Kind'] -and $entry.Kind) { $entry.Kind } else { 'Registry' }
         try {
-            if ($entry.Existed) {
-                $value = $entry.OldValue
-                if ($entry.IsBase64 -and $value -is [string]) {
-                    $value = [Convert]::FromBase64String($value)
-                }
-                if (-not (Test-Path $entry.Path)) {
-                    New-Item -Path $entry.Path -Force | Out-Null
-                }
-                # Older undo files (pre-Type field) default to DWord.
-                $type = if ($entry.PSObject.Properties['Type'] -and $entry.Type) { $entry.Type } else { 'DWord' }
-                Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $value -Type $type -Force
-                $restored++
-            } else {
-                # Value didn't exist before, remove it
-                if (Test-Path $entry.Path) {
-                    Remove-ItemProperty -Path $entry.Path -Name $entry.Name -ErrorAction SilentlyContinue
+            switch ($kind) {
+                'Service' {
+                    $target = switch -Regex ("$($entry.OldStartType)") {
+                        'Disabled' { 'Disabled' }
+                        'Manual'   { 'Manual' }
+                        'Auto'     { 'Automatic' }
+                        default    { 'Manual' }
+                    }
+                    Set-Service -Name $entry.Name -StartupType $target -ErrorAction Stop
+                    if ($entry.WasRunning) {
+                        Start-Service -Name $entry.Name -ErrorAction SilentlyContinue
+                    }
                     $restored++
+                }
+                'ScheduledTask' {
+                    Enable-ScheduledTask -TaskPath $entry.TaskPath -TaskName $entry.TaskName -ErrorAction Stop | Out-Null
+                    $restored++
+                }
+                'Feature' {
+                    Enable-WindowsOptionalFeature -Online -FeatureName $entry.FeatureName -NoRestart -ErrorAction Stop | Out-Null
+                    $restored++
+                }
+                'BcdTimeout' {
+                    $t = 30
+                    if ([int]::TryParse("$($entry.OldTimeout)", [ref]$t)) {
+                        bcdedit /timeout $t 2>&1 | Out-Null
+                        $restored++
+                    }
+                }
+                'RegistryKey' {
+                    # We only remove keys we created (Existed = false).
+                    if (-not $entry.Existed -and (Test-Path -LiteralPath $entry.Path)) {
+                        Remove-Item -LiteralPath $entry.Path -Recurse -Force -ErrorAction Stop
+                    }
+                    $restored++
+                }
+                default {
+                    # Registry entry
+                    if ($entry.Existed) {
+                        $value = $entry.OldValue
+                        if ($entry.IsBase64 -and $value -is [string]) {
+                            $value = [Convert]::FromBase64String($value)
+                        }
+                        if (-not (Test-Path $entry.Path)) {
+                            New-Item -Path $entry.Path -Force | Out-Null
+                        }
+                        # Older undo files (pre-Type field) default to DWord.
+                        $type = if ($entry.PSObject.Properties['Type'] -and $entry.Type) { $entry.Type } else { 'DWord' }
+                        Set-ItemProperty -Path $entry.Path -Name $entry.Name -Value $value -Type $type -Force
+                        $restored++
+                    } else {
+                        # Value didn't exist before, remove it
+                        if (Test-Path $entry.Path) {
+                            Remove-ItemProperty -Path $entry.Path -Name $entry.Name -ErrorAction SilentlyContinue
+                            $restored++
+                        }
+                    }
                 }
             }
         } catch {
-            Write-Warning "Failed to restore $($entry.Path)\$($entry.Name): $_"
+            Write-Warning "Failed to restore entry ($kind): $_"
             $failed++
         }
     }
@@ -158,7 +351,9 @@ function Get-UndoEntry {
 
 function Clear-UndoEntry {
     $script:UndoEntries.Clear()
+    $script:SeenKeys.Clear()
 }
 
-Export-ModuleMember -Function Save-RegistryState, Export-UndoFile, Restore-FromUndoFile,
-    Get-UndoEntry, Clear-UndoEntry, Set-UndoFileAcl
+Export-ModuleMember -Function Save-RegistryState, Save-RegistryKeyState, Save-ServiceState,
+    Save-ScheduledTaskState, Save-FeatureState, Save-BcdTimeout, Export-UndoFile,
+    Restore-FromUndoFile, Get-UndoEntry, Clear-UndoEntry, Set-UndoFileAcl, Get-UndoFileList

--- a/run.ps1
+++ b/run.ps1
@@ -1,11 +1,18 @@
 <#
 .SYNOPSIS
     One-click installer and runner for Ultimate Windows System Optimizer.
-    Downloads, extracts, and runs the optimizer automatically with admin privileges.
+    Downloads the optimizer ONCE to a local temp folder, optionally verifies
+    its SHA256, then runs it - elevating to admin from the local copy rather
+    than re-downloading.
 
 .PARAMETER Auto
     Skip every confirmation prompt in the optimizer (passes -Force to the
     main script). Off by default; opt in only for unattended runs.
+
+.PARAMETER ExpectedHash
+    Expected SHA256 of the downloaded archive. When supplied, the run aborts
+    if the download doesn't match. Can also be set via $env:UWSO_SHA256, since
+    piping into iex strips parameters.
 
 .DESCRIPTION
     Usage (paste into PowerShell):
@@ -13,28 +20,27 @@
 
     Hands-off run (no prompts):
         $env:UWSO_AUTO = '1'; irm .../run.ps1 | iex
+
+    Pin a known-good build (recommended on shared/managed machines):
+        $env:UWSO_SHA256 = '<hash printed on a trusted run>'; irm .../run.ps1 | iex
+
+    SECURITY: this downloads code from the internet and elevates it to
+    administrator. Review this script and the repository before running.
+    The script prints the downloaded archive's SHA256 so you can record and
+    pin it; supply that value via $env:UWSO_SHA256 to fail closed on tampering.
 #>
 
 param(
-    [switch]$Auto
+    [switch]$Auto,
+    [string]$ExpectedHash
 )
 
-# Allow opt-in via env var too, since piping into iex strips parameters
+# Allow opt-in via env vars too, since piping into iex strips parameters.
 if ($env:UWSO_AUTO -eq '1') { $Auto = $true }
-
-# Self-elevate to admin if not already
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-if (-not $isAdmin) {
-    Write-Host "`n  Requesting administrator privileges..." -ForegroundColor Yellow
-    $autoEnv = if ($Auto) { "`$env:UWSO_AUTO = '1'; " } else { "" }
-    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(
-        "Set-ExecutionPolicy Bypass -Scope Process -Force; ${autoEnv}irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex"
-    ))
-    Start-Process powershell.exe -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded" -Verb RunAs
-    return
+if ([string]::IsNullOrWhiteSpace($ExpectedHash) -and $env:UWSO_SHA256) {
+    $ExpectedHash = $env:UWSO_SHA256
 }
 
-Set-ExecutionPolicy Bypass -Scope Process -Force
 $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
@@ -49,25 +55,51 @@ try {
     Write-Host "  ============================================================" -ForegroundColor Cyan
     Write-Host ""
 
-    # Download
-    Write-Host "  [1/3] Downloading optimizer..." -ForegroundColor Yellow
+    # 1. Download once (no admin needed to fetch).
+    Write-Host "  [1/4] Downloading optimizer..." -ForegroundColor Yellow
     Invoke-WebRequest -Uri $repoUrl -OutFile $zipFile -UseBasicParsing
     Write-Host "  [OK]  Downloaded successfully" -ForegroundColor Green
 
-    # Extract
-    Write-Host "  [2/3] Extracting files..." -ForegroundColor Yellow
+    # 2. Integrity check. Always print the hash; verify it if one was pinned.
+    Write-Host "  [2/4] Verifying integrity..." -ForegroundColor Yellow
+    $hash = (Get-FileHash -Path $zipFile -Algorithm SHA256).Hash
+    Write-Host "  Archive SHA256: $hash" -ForegroundColor Gray
+    if ($ExpectedHash) {
+        if ($hash -ne $ExpectedHash.Trim()) {
+            throw "SHA256 mismatch - expected '$ExpectedHash' but got '$hash'. Aborting."
+        }
+        Write-Host "  [OK]  Integrity verified against pinned hash" -ForegroundColor Green
+    } else {
+        Write-Host "  [..]  No pinned hash; set `$env:UWSO_SHA256 to fail closed on tampering" -ForegroundColor DarkGray
+    }
+
+    # 3. Extract.
+    Write-Host "  [3/4] Extracting files..." -ForegroundColor Yellow
     Expand-Archive -Path $zipFile -DestinationPath $tempDir -Force
     $scriptDir = Get-ChildItem -Path $tempDir -Directory | Select-Object -First 1
+    if (-not $scriptDir) { throw "Extraction produced no directory." }
+    $mainScript = Join-Path $scriptDir.FullName "Ultimate-Windows-System-Optimizer.ps1"
+    if (-not (Test-Path $mainScript)) { throw "Optimizer script not found after extraction." }
     Write-Host "  [OK]  Extracted to temp directory" -ForegroundColor Green
 
-    # Run
-    Write-Host "  [3/3] Launching optimizer..." -ForegroundColor Yellow
+    # 4. Run the LOCAL copy, elevating if needed. We never re-download in the
+    #    elevated shell - that re-fetch was a time-of-check/time-of-use gap
+    #    where GitHub content could differ between the two downloads.
+    Write-Host "  [4/4] Launching optimizer..." -ForegroundColor Yellow
     Write-Host ""
 
-    $mainScript = Join-Path $scriptDir.FullName "Ultimate-Windows-System-Optimizer.ps1"
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
     $mainArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $mainScript)
     if ($Auto) { $mainArgs += "-Force" }
-    powershell.exe @mainArgs
+
+    if ($isAdmin) {
+        powershell.exe @mainArgs
+    } else {
+        Write-Host "  Requesting administrator privileges (running the local copy)..." -ForegroundColor Yellow
+        $proc = Start-Process powershell.exe -ArgumentList $mainArgs -Verb RunAs -PassThru
+        # Wait so the temp copy isn't deleted out from under the elevated run.
+        try { $proc.WaitForExit() } catch { $null = $_ }
+    }
 
 } catch {
     Write-Host ""

--- a/tests/Analysis.Tests.ps1
+++ b/tests/Analysis.Tests.ps1
@@ -7,58 +7,61 @@ BeforeAll {
 }
 
 Describe "System Tier Classification" {
+    # These call the real Get-SystemTier so the test fails if the product
+    # logic changes - the previous version re-implemented the if/else inline.
     It "Should classify High-End system (16GB+ RAM, 6+ cores)" {
-        $results = @{
-            TotalRAMGB = 32; CPUCores = 8; RAMUsedPct = 50;
-            StartupItems = @(); TempSizeMB = 50; ServicesToDisable = @();
-            TelemetryEnabled = $false; CurrentPowerPlan = "High performance";
-            Disks = @(); VisualEffects = "Performance"
-        }
-        # Simulate tier logic
-        if ($results.TotalRAMGB -ge 16 -and $results.CPUCores -ge 6) {
-            $tier = "High-End"
-        } elseif ($results.TotalRAMGB -ge 8 -and $results.CPUCores -ge 4) {
-            $tier = "Mid-Range"
-        } else {
-            $tier = "Low-End"
-        }
-        $tier | Should -Be "High-End"
+        Get-SystemTier -RamGB 32 -Cores 8 | Should -Be "High-End"
     }
 
     It "Should classify Mid-Range system (8GB RAM, 4 cores)" {
-        $results = @{ TotalRAMGB = 8; CPUCores = 4 }
-        if ($results.TotalRAMGB -ge 16 -and $results.CPUCores -ge 6) {
-            $tier = "High-End"
-        } elseif ($results.TotalRAMGB -ge 8 -and $results.CPUCores -ge 4) {
-            $tier = "Mid-Range"
-        } else {
-            $tier = "Low-End"
-        }
-        $tier | Should -Be "Mid-Range"
+        Get-SystemTier -RamGB 8 -Cores 4 | Should -Be "Mid-Range"
     }
 
     It "Should classify Low-End system (4GB RAM, 2 cores)" {
-        $results = @{ TotalRAMGB = 4; CPUCores = 2 }
-        if ($results.TotalRAMGB -ge 16 -and $results.CPUCores -ge 6) {
-            $tier = "High-End"
-        } elseif ($results.TotalRAMGB -ge 8 -and $results.CPUCores -ge 4) {
-            $tier = "Mid-Range"
-        } else {
-            $tier = "Low-End"
-        }
-        $tier | Should -Be "Low-End"
+        Get-SystemTier -RamGB 4 -Cores 2 | Should -Be "Low-End"
     }
 
     It "Should classify 16GB/4-core as Mid-Range (needs 6+ cores for High-End)" {
-        $results = @{ TotalRAMGB = 16; CPUCores = 4 }
-        if ($results.TotalRAMGB -ge 16 -and $results.CPUCores -ge 6) {
-            $tier = "High-End"
-        } elseif ($results.TotalRAMGB -ge 8 -and $results.CPUCores -ge 4) {
-            $tier = "Mid-Range"
-        } else {
-            $tier = "Low-End"
+        Get-SystemTier -RamGB 16 -Cores 4 | Should -Be "Mid-Range"
+    }
+}
+
+Describe "Get-PowerPlanName" {
+    It "Should extract a parenthesized name (modern powercfg output)" {
+        $out = "Power Scheme GUID: 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c  (High performance)"
+        Get-PowerPlanName $out | Should -Be "High performance"
+    }
+
+    It "Should extract a double-quoted name (legacy powercfg output)" {
+        $out = 'Power Scheme GUID: 381b4222-f694-41f0-9685-ff5bb260df2e  "Balanced"'
+        Get-PowerPlanName $out | Should -Be "Balanced"
+    }
+
+    It "Should return Unknown when no name is present" {
+        Get-PowerPlanName "no plan name here" | Should -Be "Unknown"
+    }
+}
+
+Describe "Get-HealthScore hardening" {
+    It "Should return 100 when optional keys (IsLaptop) are absent" {
+        # The post-optimization re-score can pass a partial hashtable; a
+        # missing key must not crash or wrongly deduct.
+        $results = @{
+            RAMUsedPct = 30; TempSizeMB = 10; TelemetryEnabled = $false
+            CurrentPowerPlan = "High performance"; VisualEffects = "Performance"
         }
-        $tier | Should -Be "Mid-Range"
+        Get-HealthScore -AnalysisResults $results | Should -Be 100
+    }
+
+    It "Should treat a single-element StartupItems collection as count 1" {
+        $results = @{
+            RAMUsedPct = 30; TempSizeMB = 10; ServicesToDisable = @()
+            TelemetryEnabled = $false; CurrentPowerPlan = "High performance"
+            Disks = @(); VisualEffects = "Performance"
+            StartupItems = @{ Name = "OnlyOne" }
+        }
+        # One startup item is below every threshold, so the score stays 100.
+        Get-HealthScore -AnalysisResults $results | Should -Be 100
     }
 }
 

--- a/tests/Modules.Tests.ps1
+++ b/tests/Modules.Tests.ps1
@@ -1,0 +1,92 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    foreach ($m in @('UI','UndoManager','Config','Analysis','Cleanup','Services',
+                     'Privacy','Network','Performance','Security','Explorer')) {
+        Import-Module (Join-Path $modulesPath "$m.psm1") -Force -DisableNameChecking
+    }
+}
+
+Describe "DryRun safety - no registry writes, no inflated fix counter" {
+    # The single most important safety property for a destructive tool: when
+    # DryRun is on, NOTHING should mutate the registry and the fix counter
+    # must stay at zero (issue #8 - several modules used to emit [FIX] anyway).
+    It "No section writes the registry or counts a fix in DryRun" {
+        Mock -ModuleName Config Set-ItemProperty {}
+
+        Set-DryRunMode $true
+        Reset-FixCounter
+        Clear-UndoEntry
+        try {
+            $a = @{
+                IsLaptop = $false; TotalRAMGB = 8; SystemTier = "Mid-Range"
+                OSBuild = "22000"; HasSSD = $true; HasHDD = $false
+                ServicesToDisable = @(); Disks = @()
+            }
+
+            Invoke-CleanupOptimization        -Analysis $a | Out-Null
+            Invoke-ServicesOptimization       -Analysis $a | Out-Null
+            Invoke-PowerOptimization          -Analysis $a | Out-Null
+            Invoke-VisualEffectsOptimization  -Analysis $a | Out-Null
+            Invoke-PrivacyOptimization        -Analysis $a | Out-Null
+            Invoke-NetworkOptimization        -Analysis $a | Out-Null
+            Invoke-PerformanceOptimization    -Analysis $a | Out-Null
+            Invoke-ExplorerOptimization       -Analysis $a | Out-Null
+            Invoke-SSDOptimization            -Analysis $a | Out-Null
+            Invoke-MemoryOptimization         -Analysis $a | Out-Null
+            Invoke-ScheduledTasksOptimization -Analysis $a | Out-Null
+            Invoke-ContextMenuOptimization    -Analysis $a | Out-Null
+            Invoke-BootOptimization           -Analysis $a | Out-Null
+            Invoke-DiskOptimization           -Analysis $a | Out-Null
+            Invoke-FeaturesOptimization       -Analysis $a | Out-Null
+            Invoke-NotificationsOptimization  -Analysis $a | Out-Null
+            Invoke-BackgroundAppsOptimization -Analysis $a | Out-Null
+            Invoke-SecurityOptimization       -Analysis $a | Out-Null
+
+            Get-FixCount | Should -Be 0
+            Should -Invoke -ModuleName Config Set-ItemProperty -Exactly -Times 0
+        } finally {
+            Set-DryRunMode $false
+            Reset-FixCounter
+            Clear-UndoEntry
+        }
+    }
+}
+
+Describe "Cleanup age filtering" {
+    # Issue #3 / #28: only files older than the cutoff may be deleted, and the
+    # delete is per-file so a locked/in-use file is skipped, not fatal.
+    BeforeAll {
+        $script:sandbox = Join-Path $env:TEMP "uwso_cleanup_$(Get-Random)"
+        New-Item -ItemType Directory -Path $script:sandbox -Force | Out-Null
+    }
+    AfterAll {
+        Remove-Item -LiteralPath $script:sandbox -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
+    It "Deletes files older than the age threshold but keeps fresh ones" {
+        $old = Join-Path $script:sandbox "old.tmp"
+        $new = Join-Path $script:sandbox "new.tmp"
+        "x" * 2048 | Out-File -LiteralPath $old -Encoding ascii
+        "y" * 2048 | Out-File -LiteralPath $new -Encoding ascii
+        # Backdate the "old" file two days.
+        (Get-Item -LiteralPath $old).LastWriteTime = (Get-Date).AddDays(-2)
+
+        $freed = Clear-OldFile -Path $script:sandbox -MinAgeHours 24
+
+        Test-Path -LiteralPath $old | Should -Be $false
+        Test-Path -LiteralPath $new | Should -Be $true
+        $freed | Should -BeGreaterThan 0
+    }
+
+    It "Respects ExcludePaths" {
+        $sub = Join-Path $script:sandbox "keep"
+        New-Item -ItemType Directory -Path $sub -Force | Out-Null
+        $protected = Join-Path $sub "protected.tmp"
+        "z" * 2048 | Out-File -LiteralPath $protected -Encoding ascii
+        (Get-Item -LiteralPath $protected).LastWriteTime = (Get-Date).AddDays(-5)
+
+        Clear-OldFile -Path $script:sandbox -MinAgeHours 24 -ExcludePaths @($sub) | Out-Null
+
+        Test-Path -LiteralPath $protected | Should -Be $true
+    }
+}

--- a/tests/Optimizer.Tests.ps1
+++ b/tests/Optimizer.Tests.ps1
@@ -258,4 +258,73 @@ Describe "Set-RegValue path validation" {
         (Set-RegValue "" "X" 1)  | Should -Be $false
         (Set-RegValue "   " "X" 1) | Should -Be $false
     }
+
+    It "Should reject an unknown registry value type" {
+        $result = Set-RegValue "HKCU:\Software\UWSOTypeTest_$(Get-Random)" "X" 1 "NotARealType"
+        $result | Should -Be $false
+    }
+}
+
+Describe "Optimization Presets" {
+    It "Should expose the documented preset names" {
+        $names = Get-PresetNameList
+        $names | Should -Contain "Balanced"
+        $names | Should -Contain "Gaming"
+        $names | Should -Contain "Privacy"
+        $names | Should -Contain "Minimal"
+    }
+
+    It "Test-PresetName accepts a known preset and rejects an unknown one" {
+        Test-PresetName "Gaming"  | Should -Be $true
+        Test-PresetName "Nonsense" | Should -Be $false
+        Test-PresetName ""         | Should -Be $false
+    }
+
+    It "Balanced preset resolves to every section" {
+        $sections = Resolve-EnabledSection -PresetName "Balanced"
+        ($sections | Sort-Object) | Should -Be ((Get-ValidSectionList) | Sort-Object)
+    }
+
+    It "Gaming preset excludes Privacy and Security" {
+        $sections = Resolve-EnabledSection -PresetName "Gaming"
+        $sections | Should -Not -Contain "Privacy"
+        $sections | Should -Not -Contain "Security"
+        $sections | Should -Contain "Performance"
+    }
+
+    It "-Only overrides a preset entirely" {
+        $sections = Resolve-EnabledSection -PresetName "Gaming" -Only @("Privacy")
+        $sections | Should -Be @("Privacy")
+    }
+
+    It "-Skip removes sections from a preset" {
+        $sections = Resolve-EnabledSection -PresetName "Privacy" -Skip @("Security")
+        $sections | Should -Not -Contain "Security"
+        $sections | Should -Contain "Privacy"
+    }
+
+    It "Returns sections in canonical order" {
+        $all = Get-ValidSectionList
+        $sections = Resolve-EnabledSection -PresetName "Gaming"
+        $indices = $sections | ForEach-Object { [array]::IndexOf($all, $_) }
+        $sorted = $indices | Sort-Object
+        "$indices" | Should -Be "$sorted"
+    }
+}
+
+Describe "Bloat list safety" {
+    It "Should NOT include WSearch (Start Menu/Explorer/Outlook depend on it - #20)" {
+        $names = (Get-BloatServiceDefinition).Name
+        $names | Should -Not -Contain "WSearch"
+    }
+}
+
+Describe "Get-OSBuildNumber" {
+    It "Parses a numeric build string" {
+        Get-OSBuildNumber "22631" | Should -Be 22631
+    }
+    It "Returns 0 for an empty or non-numeric build" {
+        Get-OSBuildNumber ""    | Should -Be 0
+        Get-OSBuildNumber "n/a" | Should -Be 0
+    }
 }

--- a/tests/UndoManager.Tests.ps1
+++ b/tests/UndoManager.Tests.ps1
@@ -54,11 +54,69 @@ Describe "Undo File Generation" {
         $entries = Get-UndoEntry
         $entries.Count | Should -Be 0
     }
+
+    It "Should record only the first-seen value when the same key is saved twice" {
+        Save-RegistryState -Path "HKCU:\Dup" -Name "N" -NewValue 1
+        Save-RegistryState -Path "HKCU:\Dup" -Name "N" -NewValue 2
+        $entries = Get-UndoEntry
+        $entries.Count | Should -Be 1
+        $entries[0].NewValue | Should -Be 1
+    }
+
+    It "Should record a registry KEY state for key-presence tweaks" {
+        Save-RegistryKeyState -Path "HKCU:\Software\UWSOKeyTest_$(Get-Random)"
+        $entries = Get-UndoEntry
+        $entries.Count | Should -Be 1
+        $entries[0].Kind | Should -Be "RegistryKey"
+        $entries[0].ContainsKey('Existed') | Should -Be $true
+    }
 }
 
 Describe "Undo File Restore" {
-    It "Should fail gracefully with non-existent file" {
-        { Restore-FromUndoFile -FilePath "C:\nonexistent\file.json" } | Should -Throw
+    It "Should fail gracefully (return false, not throw) with a non-existent file" {
+        # A throw here would fail the test; we also assert the graceful $false.
+        # 3>$null suppresses the expected warning stream.
+        $result = Restore-FromUndoFile -FilePath "C:\nonexistent\file.json" 3>$null
+        $result | Should -Be $false
+    }
+
+    It "Should return false on malformed JSON" {
+        $bad = Join-Path $env:TEMP "uwso_bad_$(Get-Random).json"
+        "{ this is not valid json " | Out-File -FilePath $bad -Encoding UTF8
+        try {
+            Restore-FromUndoFile -FilePath $bad | Should -Be $false
+        } finally {
+            Remove-Item $bad -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Should coerce a single-entry (non-array) undo file without throwing" {
+        $single = Join-Path $env:TEMP "uwso_single_$(Get-Random).json"
+        $testPath = "HKCU:\Software\UWSOSingle_$(Get-Random)"
+        ([pscustomobject]@{
+            Kind = "Registry"; Path = $testPath; Name = "V"; NewValue = 1
+            OldValue = $null; Type = "DWord"; Existed = $false; IsBase64 = $false
+        }) | ConvertTo-Json | Out-File -FilePath $single -Encoding UTF8
+        try {
+            { Restore-FromUndoFile -FilePath $single } | Should -Not -Throw
+        } finally {
+            Remove-Item $single -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Should remove a key we created (RegistryKey, Existed=false) on restore" {
+        $key = "HKCU:\Software\UWSOKeyRestore_$(Get-Random)"
+        New-Item -Path $key -Force | Out-Null
+        $file = Join-Path $env:TEMP "uwso_key_$(Get-Random).json"
+        @( @{ Kind = "RegistryKey"; Path = $key; Existed = $false } ) |
+            ConvertTo-Json | Out-File -FilePath $file -Encoding UTF8
+        try {
+            Restore-FromUndoFile -FilePath $file | Out-Null
+            Test-Path $key | Should -Be $false
+        } finally {
+            Remove-Item $key -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item $file -Force -ErrorAction SilentlyContinue
+        }
     }
 
     It "Should read and process a valid undo file" {
@@ -144,5 +202,47 @@ Describe "Undo File Restore" {
 
         Remove-Item -Path $testPath -Recurse -Force -ErrorAction SilentlyContinue
         Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Describe "Non-registry undo restore (mocked - no host changes)" {
+    It "Should restore a Service entry via Set-Service" {
+        Mock -ModuleName UndoManager Set-Service {}
+        Mock -ModuleName UndoManager Start-Service {}
+        $file = Join-Path $env:TEMP "uwso_svc_$(Get-Random).json"
+        @( @{ Kind = "Service"; Name = "Fax"; OldStartType = "Manual"; WasRunning = $false } ) |
+            ConvertTo-Json | Out-File -FilePath $file -Encoding UTF8
+        try {
+            Restore-FromUndoFile -FilePath $file | Should -Be $true
+            Should -Invoke -ModuleName UndoManager Set-Service -Times 1
+        } finally {
+            Remove-Item $file -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Should restore a ScheduledTask entry via Enable-ScheduledTask" {
+        Mock -ModuleName UndoManager Enable-ScheduledTask {}
+        $file = Join-Path $env:TEMP "uwso_task_$(Get-Random).json"
+        @( @{ Kind = "ScheduledTask"; TaskPath = "\Microsoft\Windows\Foo\"; TaskName = "Bar" } ) |
+            ConvertTo-Json | Out-File -FilePath $file -Encoding UTF8
+        try {
+            Restore-FromUndoFile -FilePath $file | Should -Be $true
+            Should -Invoke -ModuleName UndoManager Enable-ScheduledTask -Times 1
+        } finally {
+            Remove-Item $file -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    It "Should restore a Feature entry via Enable-WindowsOptionalFeature" {
+        Mock -ModuleName UndoManager Enable-WindowsOptionalFeature {}
+        $file = Join-Path $env:TEMP "uwso_feat_$(Get-Random).json"
+        @( @{ Kind = "Feature"; FeatureName = "WindowsMediaPlayer" } ) |
+            ConvertTo-Json | Out-File -FilePath $file -Encoding UTF8
+        try {
+            Restore-FromUndoFile -FilePath $file | Should -Be $true
+            Should -Invoke -ModuleName UndoManager Enable-WindowsOptionalFeature -Times 1
+        } finally {
+            Remove-Item $file -Force -ErrorAction SilentlyContinue
+        }
     }
 }


### PR DESCRIPTION
## Summary

A comprehensive v4.0 release that closes every open bug, security, and enhancement issue, then layers on new features. CI-equivalent checks pass locally: PSScriptAnalyzer is clean and Pester is **84/84** (up from 57).

## Bug & safety fixes
- **Power plan parsing** (latent, high impact): modern `powercfg` prints the plan name in parentheses, but the regex expected quotes, so the active plan was always `"Unknown"`. This corrupted the analysis readout and the health-score deduction. Now parsed via a tested `Get-PowerPlanName` helper that accepts both forms.
- **Post-optimization score** is built by cloning the original analysis instead of a partial literal, so before/after scores share a schema (no more dropped `IsLaptop`).
- **DryRun no longer inflates the fix counter** in Privacy, Performance, Network, Security, Notifications, and BackgroundApps. Closes #8.
- **Temp cleanup** only deletes files older than 24h, one file at a time (locked/in-use files are skipped instead of wedging Windows servicing), skips reparse points, reports accurate freed totals, and excludes the optimizer's own data dir. Closes #3, #28.
- **Fast Startup** is skipped on dual-boot systems and when hibernation is unavailable. Closes #22.
- **Classic context-menu** restoration is now recorded in the undo file (key-level). Closes #14.
- **Undo captures non-registry changes** - service startup types, scheduled task states, optional feature states, and the boot menu timeout. Closes #2.
- **Windows Search (WSearch)** is no longer disabled by default; core search depends on it. Closes #20.
- Undo entries are de-duplicated (genuine pre-run value preserved), `Restore-FromUndoFile` validates JSON and fails gracefully, NDU targets `CurrentControlSet`, external tool failures are reported as skips, and blank OS-build strings are guarded.

## Security (run.ps1)
- Downloads once and elevates the **local copy** instead of re-running `irm | iex` in the elevated shell (closes the TOCTOU re-download). Closes #10.
- Prints the archive **SHA256** and supports pinning via `-ExpectedHash` / `$env:UWSO_SHA256`. Closes #11.

## New features
- `-Preset` with `Balanced`, `Gaming`, `Privacy`, `Minimal` (composes with `-Skip`; `-Only` overrides).
- `-CheckOnly` analyze-and-score mode (no changes, no restore point, no undo file).
- `-Undo Latest` and `-ListUndo`.
- A machine-readable **JSON report** written alongside the log.
- Restore-point existence is verified before the run relies on it.

## Tests (closes #18)
- Real `Get-SystemTier` test (was re-implemented inline), `Get-PowerPlanName`, and `Get-HealthScore` hardening tests.
- Undo de-dup, malformed-JSON, single-entry, key-removal, and mocked Service/ScheduledTask/Feature restore tests (no host mutation).
- Preset resolution, registry value-type rejection, and a **DryRun no-mutation integration test** across every section.
- Cleanup age-filter tests.

## Docs
- README: new flags, expanded undo coverage, JSON report, installer security note; corrected log location, module map, and the stale Search-Indexer claim.
- New `CHANGELOG.md`.

## Test plan
- [x] `PSScriptAnalyzer` (Warning,Error; CI exclusions) - clean
- [x] `Invoke-Pester ./tests` - 84/84 passing
- [x] Smoke-tested preset resolution, power-plan parsing, after-score clone, and report build under `Set-StrictMode -Version Latest`
- [ ] Manual run on a Windows 10/11 host as Administrator (full optimize + `-Undo Latest` round-trip) - not run in CI; recommended before merge

Closes #2, #3, #8, #10, #11, #14, #18, #20, #22, #28.