### PR TITLE
Safer temp cleanup, plus a deterministic undo restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A PowerShell script that analyzes Windows 10/11 systems and applies intelligent,
 
 - **Deep system analysis** - detects CPU, RAM, GPU, SSD/HDD, laptop vs. desktop, and assigns a system tier (Low-End, Mid-Range, High-End)
 - **Health scoring** - calculates a real 0-100 health score before and after optimization
-- **Temp file cleanup** - removes user temp, Windows temp, internet cache, update cache, crash dumps, thumbnail cache, and empties the Recycle Bin
+- **Temp file cleanup** - removes user temp, Windows temp, internet cache, update cache, crash dumps, thumbnail cache, and empties the Recycle Bin. Only files older than 24 hours are touched, so anything from the current session stays put, and it deletes files rather than wiping whole directory trees out from under running apps
 - **Service trimming** - disables telemetry, Xbox, fax, geolocation, and other commonly unnecessary services
 - **Power plan tuning** - activates Ultimate/High Performance on desktops; optimizes AC vs. battery profiles on laptops
 - **Visual effects optimization** - adjusts animations and effects based on system tier
@@ -139,7 +139,7 @@ Each optimization module exports a single `Invoke-*Optimization` function. The a
 | Gaming settings | Game Mode, Game DVR, GPU scheduling, mouse acceleration |
 | Security settings | Remote Desktop, Remote Assistance, SMBv1, AutoRun, Firewall |
 | Optional features | Windows Media Player, Work Folders, Fax client |
-| Disk optimization | TRIM on SSDs, defrag on HDDs, temp file removal |
+| Disk optimization | TRIM on SSDs, defrag on HDDs, temp file removal (files older than 24h only) |
 
 ## Output
 

--- a/modules/Cleanup.psm1
+++ b/modules/Cleanup.psm1
@@ -1,5 +1,27 @@
 # Cleanup.psm1 - Temp files, disk cleanup, recycle bin
 
+function Get-CleanupMinAgeHour {
+    # Files touched more recently than this are assumed to belong to an
+    # active session (current temp files, in-progress downloads, open
+    # handles) and are left alone. Issue #3 / #28: the cleanup used to
+    # delete everything it could reach, which removed in-use files.
+    return 24
+}
+
+function Select-AgedItem {
+    # Pure age filter. Keeps only items whose LastWriteTime is older than
+    # MinAgeHour before ReferenceTime. Pulled out of the cleanup loop so it
+    # can be unit tested without touching the disk.
+    param(
+        [object[]]$Item,
+        [int]$MinAgeHour = 24,
+        [datetime]$ReferenceTime = (Get-Date)
+    )
+    if (-not $Item) { return @() }
+    $cutoff = $ReferenceTime.AddHours(-[math]::Abs($MinAgeHour))
+    @($Item | Where-Object { $_.LastWriteTime -lt $cutoff })
+}
+
 function Invoke-CleanupOptimization {
     param([hashtable]$Analysis)
 
@@ -19,16 +41,27 @@ function Invoke-CleanupOptimization {
         @{ Path = "$env:WINDIR\Minidump";                                          Desc = "Minidump Files" }
     )
 
+    $minAge = Get-CleanupMinAgeHour
+    $now = Get-Date
+
     $totalCleaned = 0
     foreach ($cp in $cleanPaths) {
         if (Test-Path $cp.Path) {
             if ($DryRun) {
-                Write-Dry "Would clean $($cp.Desc) at $($cp.Path)"
+                Write-Dry "Would clean $($cp.Desc) at $($cp.Path) (files older than $minAge h)"
                 continue
             }
             try {
                 $before = (Get-ChildItem $cp.Path -Recurse -Force -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum
-                Get-ChildItem $cp.Path -Recurse -Force -ErrorAction SilentlyContinue | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue
+                # Files only, never a recursive directory delete: removing a
+                # whole tree could take a file another process still has open
+                # (issue #28). Age filter keeps anything from the last day so
+                # in-use temp files survive (issue #3).
+                $candidates = Get-ChildItem $cp.Path -Recurse -Force -File -ErrorAction SilentlyContinue
+                $aged = Select-AgedItem -Item $candidates -MinAgeHour $minAge -ReferenceTime $now
+                foreach ($f in $aged) {
+                    Remove-Item -LiteralPath $f.FullName -Force -ErrorAction SilentlyContinue
+                }
                 $after = (Get-ChildItem $cp.Path -Recurse -Force -File -ErrorAction SilentlyContinue | Measure-Object Length -Sum).Sum
                 $freed = [math]::Round(($before - $after) / 1MB, 1)
                 if ($freed -gt 0) {
@@ -97,4 +130,4 @@ function Invoke-CleanupOptimization {
     }
 }
 
-Export-ModuleMember -Function Invoke-CleanupOptimization
+Export-ModuleMember -Function Invoke-CleanupOptimization, Get-CleanupMinAgeHour, Select-AgedItem

--- a/modules/UndoManager.psm1
+++ b/modules/UndoManager.psm1
@@ -112,7 +112,12 @@ function Restore-FromUndoFile {
     )
 
     if (-not (Test-Path $FilePath)) {
-        Write-Error "Undo file not found: $FilePath"
+        # Warn, don't error. A missing path is a user mistake, not a fault,
+        # and the caller already handles the $false return with a friendly
+        # message. Write-Error made the outcome depend on the caller's
+        # ErrorActionPreference: it returned $false locally but threw under
+        # Stop (as CI runs), so the behavior was never deterministic.
+        Write-Warning "Undo file not found: $FilePath"
         return $false
     }
 

--- a/tests/Cleanup.Tests.ps1
+++ b/tests/Cleanup.Tests.ps1
@@ -1,0 +1,70 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")      -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")  -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Cleanup.psm1") -Force -DisableNameChecking
+}
+
+Describe "Get-CleanupMinAgeHour" {
+    # Issue #3: temp cleanup needs a floor so files from the active session
+    # are not deleted out from under it.
+    It "Should return a positive whole number of hours" {
+        $h = Get-CleanupMinAgeHour
+        $h | Should -BeOfType [int]
+        $h | Should -BeGreaterThan 0
+    }
+}
+
+Describe "Select-AgedItem" {
+    # Issue #3 / #28: only files older than the window are eligible for
+    # deletion. These run against synthetic objects so nothing touches disk.
+    BeforeEach {
+        $script:ref = Get-Date "2026-06-02T12:00:00"
+    }
+
+    It "Should keep an item older than the window" {
+        $old = [pscustomobject]@{ FullName = 'old.tmp'; LastWriteTime = $script:ref.AddHours(-48) }
+        $result = Select-AgedItem -Item @($old) -MinAgeHour 24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 1
+        $result[0].FullName | Should -Be 'old.tmp'
+    }
+
+    It "Should drop an item newer than the window" {
+        $fresh = [pscustomobject]@{ FullName = 'fresh.tmp'; LastWriteTime = $script:ref.AddHours(-1) }
+        $result = Select-AgedItem -Item @($fresh) -MinAgeHour 24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 0
+    }
+
+    It "Should split a mixed set, keeping only the aged files" {
+        $items = @(
+            [pscustomobject]@{ FullName = 'a'; LastWriteTime = $script:ref.AddHours(-72) }
+            [pscustomobject]@{ FullName = 'b'; LastWriteTime = $script:ref.AddHours(-2)  }
+            [pscustomobject]@{ FullName = 'c'; LastWriteTime = $script:ref.AddHours(-25) }
+        )
+        $result = Select-AgedItem -Item $items -MinAgeHour 24 -ReferenceTime $script:ref
+        ($result | ForEach-Object FullName) | Should -Be @('a', 'c')
+    }
+
+    It "Should treat an item exactly at the cutoff as still in use (not deleted)" {
+        # cutoff is strict (<), so a file at precisely 24h is kept.
+        $edge = [pscustomobject]@{ FullName = 'edge'; LastWriteTime = $script:ref.AddHours(-24) }
+        $result = Select-AgedItem -Item @($edge) -MinAgeHour 24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 0
+    }
+
+    It "Should return an empty array for empty input" {
+        $result = Select-AgedItem -Item @() -MinAgeHour 24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 0
+    }
+
+    It "Should return an empty array for null input" {
+        $result = Select-AgedItem -Item $null -MinAgeHour 24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 0
+    }
+
+    It "Should tolerate a negative age window the same as its absolute value" {
+        $old = [pscustomobject]@{ FullName = 'old'; LastWriteTime = $script:ref.AddHours(-48) }
+        $result = Select-AgedItem -Item @($old) -MinAgeHour -24 -ReferenceTime $script:ref
+        $result.Count | Should -Be 1
+    }
+}

--- a/tests/UndoManager.Tests.ps1
+++ b/tests/UndoManager.Tests.ps1
@@ -58,7 +58,12 @@ Describe "Undo File Generation" {
 
 Describe "Undo File Restore" {
     It "Should fail gracefully with non-existent file" {
-        { Restore-FromUndoFile -FilePath "C:\nonexistent\file.json" } | Should -Throw
+        # Graceful means it returns false and does not throw, regardless of
+        # the caller's ErrorActionPreference. The main script depends on the
+        # boolean to print a rollback message instead of crashing.
+        $script:undoResult = $true
+        { $script:undoResult = Restore-FromUndoFile -FilePath "C:\nonexistent\file.json" 3>$null } | Should -Not -Throw
+        $script:undoResult | Should -Be $false
     }
 
     It "Should read and process a valid undo file" {


### PR DESCRIPTION
The cleanup module had two safety bugs that turned out to need the same fix. While I was in the tests I also ran down one that was passing on CI but failing locally, which meant the suite was never really agreeing with itself.

What changed:

- Temp cleanup only deletes files older than a 24 hour window now, so anything the current session still has open is left alone (#3).
- It deletes files directly instead of recursively wiping whole directory trees, which could take a file another process was still using (#28).
- The age check is its own small pure function (`Select-AgedItem`), so it gets unit tests without touching the disk. Coverage includes the cutoff math, the exact boundary, a mixed old/recent set, and empty or null input.
- `Restore-FromUndoFile` now returns false on a missing undo file instead of throwing. The old `Write-Error` made the result depend on the caller's `ErrorActionPreference`, so the test went green under Stop (CI) and red under the default Continue (local). The main script reads that boolean to print its rollback message, so false is the right contract. Test updated to check it.
- README spells out the age window and the file-only deletion.

Verification: full Pester suite passes locally under both the default and Stop error preferences (65 tests), and PSScriptAnalyzer is clean with the CI ruleset. Could not run them on this machine before, so this run was the first real local pass.

Closes #3
Closes #28

Progresses #18 (test coverage for the cleanup module; the other modules are still open).
