### PR TITLE
Re-run the local run.ps1 on elevation instead of re-downloading it

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -22,15 +22,45 @@ param(
 # Allow opt-in via env var too, since piping into iex strips parameters
 if ($env:UWSO_AUTO -eq '1') { $Auto = $true }
 
+# Raw URL of this bootstrap script. Only used as a fallback for the case where
+# run.ps1 was piped straight into the shell (irm ... | iex) and so has no
+# on-disk copy to re-run when it elevates.
+$RunScriptUrl = "https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1"
+
+function Get-ElevationArgumentString {
+    # Build the powershell.exe argument string used to relaunch this installer
+    # with admin rights. Issue #10: when run.ps1 already exists on disk, re-run
+    # that exact file with -File so the elevated process runs the same code the
+    # user looked at, with no second network fetch. Fall back to re-downloading
+    # only when there is no local copy (the irm | iex one-liner).
+    param(
+        [string]$LocalScriptPath,
+        [switch]$Auto
+    )
+
+    if ($LocalScriptPath -and (Test-Path -LiteralPath $LocalScriptPath)) {
+        $argString = "-NoProfile -ExecutionPolicy Bypass -File `"$LocalScriptPath`""
+        if ($Auto) { $argString += " -Auto" }
+        return $argString
+    }
+
+    $autoEnv = if ($Auto) { "`$env:UWSO_AUTO = '1'; " } else { "" }
+    $command = "Set-ExecutionPolicy Bypass -Scope Process -Force; ${autoEnv}irm $RunScriptUrl | iex"
+    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($command))
+    return "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded"
+}
+
+# Tests dot-source this file to exercise Get-ElevationArgumentString without kicking
+# off a real install (which self-elevates and downloads). Real entry points -
+# irm | iex, -File, & ./run.ps1 - never set InvocationName to '.'.
+if ($MyInvocation.InvocationName -eq '.') { return }
+
 # Self-elevate to admin if not already
 $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 if (-not $isAdmin) {
     Write-Host "`n  Requesting administrator privileges..." -ForegroundColor Yellow
-    $autoEnv = if ($Auto) { "`$env:UWSO_AUTO = '1'; " } else { "" }
-    $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(
-        "Set-ExecutionPolicy Bypass -Scope Process -Force; ${autoEnv}irm https://raw.githubusercontent.com/TiltedLunar123/Ultimate-Windows-System-Optimizer/main/run.ps1 | iex"
-    ))
-    Start-Process powershell.exe -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded" -Verb RunAs
+    $elevationArgs = Get-ElevationArgumentString -LocalScriptPath $PSCommandPath -Auto:$Auto
+    Start-Process powershell.exe -ArgumentList $elevationArgs -Verb RunAs
     return
 }
 

--- a/tests/Run.Tests.ps1
+++ b/tests/Run.Tests.ps1
@@ -1,0 +1,66 @@
+BeforeAll {
+    # Dot-source the installer so Get-ElevationArgumentString is in scope. run.ps1's
+    # dot-source guard keeps the self-elevate/download body from running here.
+    . (Join-Path $PSScriptRoot "..\run.ps1")
+}
+
+Describe "Get-ElevationArgumentString" {
+    # Issue #10: when run.ps1 already lives on disk, elevating should re-run that
+    # exact file instead of pulling a fresh copy off the network, so the elevated
+    # process runs the same code the user inspected.
+
+    Context "when run.ps1 exists on disk" {
+        BeforeEach {
+            $script:localCopy = Join-Path ([System.IO.Path]::GetTempPath()) ("uwso_run_" + [Guid]::NewGuid().ToString('N') + ".ps1")
+            Set-Content -LiteralPath $script:localCopy -Value '# stand-in for run.ps1'
+        }
+        AfterEach {
+            Remove-Item -LiteralPath $script:localCopy -Force -ErrorAction SilentlyContinue
+        }
+
+        It "Should relaunch the local file with -File and not re-download" {
+            $result = Get-ElevationArgumentString -LocalScriptPath $script:localCopy
+            $result | Should -BeLike "*-File*"
+            $result | Should -Not -BeLike "*-EncodedCommand*"
+        }
+
+        It "Should quote the script path so spaces survive" {
+            $result = Get-ElevationArgumentString -LocalScriptPath $script:localCopy
+            $result | Should -BeLike "*-File `"$($script:localCopy)`"*"
+        }
+
+        It "Should carry -Auto through when requested" {
+            $result = Get-ElevationArgumentString -LocalScriptPath $script:localCopy -Auto
+            $result | Should -BeLike "*-Auto*"
+        }
+
+        It "Should leave -Auto off by default" {
+            $result = Get-ElevationArgumentString -LocalScriptPath $script:localCopy
+            $result | Should -Not -BeLike "*-Auto*"
+        }
+    }
+
+    Context "when there is no local copy (piped via irm | iex)" {
+        It "Should fall back to an encoded re-download command for an empty path" {
+            $result = Get-ElevationArgumentString -LocalScriptPath ""
+            $result | Should -BeLike "*-EncodedCommand*"
+            $result | Should -Not -BeLike "*-File*"
+        }
+
+        It "Should fall back when the path does not point at a real file" {
+            $missing = Join-Path ([System.IO.Path]::GetTempPath()) ("uwso_missing_" + [Guid]::NewGuid().ToString('N') + ".ps1")
+            $result = Get-ElevationArgumentString -LocalScriptPath $missing
+            $result | Should -BeLike "*-EncodedCommand*"
+            $result | Should -Not -BeLike "*-File*"
+        }
+
+        It "Should still encode the unattended opt-in in the fallback command" {
+            # The fallback sets UWSO_AUTO so the re-downloaded run keeps running
+            # hands-off. Decode the base64 payload back and check for it.
+            $result = Get-ElevationArgumentString -LocalScriptPath "" -Auto
+            $encoded = ($result -split '-EncodedCommand ')[-1].Trim()
+            $decoded = [Text.Encoding]::Unicode.GetString([Convert]::FromBase64String($encoded))
+            $decoded | Should -BeLike "*UWSO_AUTO*"
+        }
+    }
+}


### PR DESCRIPTION
Issue #10: when run.ps1 is launched from a saved copy, the self-elevation step
rebuilt the command as `irm .../run.ps1 | iex`, so it fetched a fresh copy from
GitHub and ran that with admin rights rather than the file already on disk. The
elevated code could differ from what the user reviewed, and it breaks any
offline or pinned use.

What changed:
- A new `Get-ElevationArgumentString` helper builds the elevated argument
  string. With a real local path it relaunches `-File <path>` (quoted, and
  carrying -Auto through). With no local copy it keeps the encoded
  `irm | iex` re-download, so the paste-and-run one-liner still works.
- A small dot-source guard lets the tests reach the helper without running the
  installer body (which self-elevates and downloads).
- tests/Run.Tests.ps1 covers both branches: local file vs encoded fallback,
  -Auto passthrough, and missing or empty paths.

Checks: PSScriptAnalyzer clean, full Pester suite green (72 passing).

Heads up: PR #41 (v4.0-upgrade) lists this issue in its scope but has not moved
in a couple of weeks. This is a small, isolated fix on main, like the recent
daily PRs that already merged alongside that branch. If #41 lands first, this
can be dropped or rebased.

Closes #10.
