### PR TITLE
test: add unit coverage for the Config and UI modules

### DIFF
--- a/tests/Config.Tests.ps1
+++ b/tests/Config.Tests.ps1
@@ -1,0 +1,131 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")     -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1") -Force -DisableNameChecking
+}
+
+Describe "Test-RegPathAllowed" {
+    # This is the allow-list that keeps Set-RegValue from writing anywhere
+    # outside the standard registry hives. It is a security boundary, so the
+    # accept and reject sides both need to be pinned down.
+    It "Should accept each of the standard hive prefixes" {
+        foreach ($p in @(
+            'HKCU:\Software\Test',
+            'HKLM:\SYSTEM\CurrentControlSet',
+            'HKCR:\.txt',
+            'HKU:\.DEFAULT',
+            'HKCC:\Software')) {
+            Test-RegPathAllowed -Path $p | Should -BeTrue -Because "$p is a real hive"
+        }
+    }
+
+    It "Should match the prefix without caring about case" {
+        Test-RegPathAllowed -Path 'hklm:\software\foo' | Should -BeTrue
+        Test-RegPathAllowed -Path 'HkCu:\Software\Bar'  | Should -BeTrue
+    }
+
+    It "Should reject a hive name that is missing the colon-backslash" {
+        Test-RegPathAllowed -Path 'HKLM\Software\Foo' | Should -BeFalse
+    }
+
+    It "Should reject the long-form hive names" {
+        Test-RegPathAllowed -Path 'HKEY_LOCAL_MACHINE\Software' | Should -BeFalse
+    }
+
+    It "Should reject a plain filesystem path" {
+        Test-RegPathAllowed -Path 'C:\Windows\System32' | Should -BeFalse
+    }
+
+    It "Should reject empty, whitespace, and null input" {
+        Test-RegPathAllowed -Path ''    | Should -BeFalse
+        Test-RegPathAllowed -Path '   ' | Should -BeFalse
+        Test-RegPathAllowed -Path $null | Should -BeFalse
+    }
+}
+
+Describe "Test-SectionEnabled" {
+    # Drives the -Only / -Skip filtering. With neither switch every section
+    # runs; -Only restricts to a set; -Skip removes from it; and -Only wins
+    # when both are supplied.
+    It "Should enable any section when neither Only nor Skip is given" {
+        Test-SectionEnabled -SectionName 'Privacy' | Should -BeTrue
+    }
+
+    It "Should keep only the named sections when Only is set" {
+        Test-SectionEnabled -SectionName 'Privacy' -Only @('Privacy', 'Network') | Should -BeTrue
+        Test-SectionEnabled -SectionName 'Cleanup' -Only @('Privacy', 'Network') | Should -BeFalse
+    }
+
+    It "Should drop the named sections when Skip is set" {
+        Test-SectionEnabled -SectionName 'Privacy' -Skip @('Privacy') | Should -BeFalse
+        Test-SectionEnabled -SectionName 'Network' -Skip @('Privacy') | Should -BeTrue
+    }
+
+    It "Should let Only take precedence when both Only and Skip are given" {
+        # Only is checked first, so Skip is ignored once Only is present.
+        Test-SectionEnabled -SectionName 'Privacy' -Only @('Privacy') -Skip @('Privacy') | Should -BeTrue
+        Test-SectionEnabled -SectionName 'Network' -Only @('Privacy') -Skip @('Network') | Should -BeFalse
+    }
+}
+
+Describe "Constant section and bloat tables" {
+    It "Should expose a non-empty, duplicate-free section list" {
+        $sections = Get-ValidSectionList
+        $sections.Count | Should -BeGreaterThan 0
+        $sections | Should -Contain 'Privacy'
+        $sections | Should -Contain 'Security'
+        ($sections | Sort-Object -Unique).Count | Should -Be $sections.Count
+    }
+
+    It "Should give every bloat service a name and a description" {
+        $services = Get-BloatServiceDefinition
+        $services.Count | Should -BeGreaterThan 0
+        foreach ($svc in $services) {
+            $svc.Name | Should -Not -BeNullOrEmpty
+            $svc.Desc | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It "Should not list the same bloat service twice" {
+        $names = (Get-BloatServiceDefinition).Name
+        ($names | Sort-Object -Unique).Count | Should -Be $names.Count
+    }
+
+    It "Should point every scheduled-task entry at a Windows task path" {
+        $tasks = Get-BloatScheduledTaskList
+        $tasks.Count | Should -BeGreaterThan 0
+        foreach ($t in $tasks) {
+            $t | Should -BeLike '\Microsoft\Windows\*'
+        }
+    }
+
+    It "Should return a non-empty feature list" {
+        (Get-FeaturesToDisable).Count | Should -BeGreaterThan 0
+    }
+}
+
+Describe "Dry-run state" {
+    AfterEach {
+        # Leave the flag the way the rest of the suite expects it.
+        Set-DryRunMode -Enabled $false
+    }
+
+    It "Should round-trip the dry-run flag" {
+        Set-DryRunMode -Enabled $true
+        Get-DryRunMode | Should -BeTrue
+        Set-DryRunMode -Enabled $false
+        Get-DryRunMode | Should -BeFalse
+    }
+}
+
+Describe "Get-OptimizerDataDir" {
+    It "Should return a path that exists and can be written to" {
+        $dir = Get-OptimizerDataDir
+        $dir | Should -Not -BeNullOrEmpty
+        Test-Path -LiteralPath $dir | Should -BeTrue
+        # The contract is a writable directory, so prove a probe file lands.
+        $probe = Join-Path $dir (".uwso_test_" + [Guid]::NewGuid().ToString('N'))
+        { Set-Content -LiteralPath $probe -Value 'x' -ErrorAction Stop } | Should -Not -Throw
+        Remove-Item -LiteralPath $probe -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/UI.Tests.ps1
+++ b/tests/UI.Tests.ps1
@@ -1,0 +1,49 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1") -Force -DisableNameChecking
+}
+
+Describe "Fix counter" {
+    # Issue #8 was about this counter getting inflated by dry-run output. The
+    # contract is simple: reset clears it, an applied fix bumps it, and a
+    # second reset clears it again. Guard all three so a regression shows up.
+    BeforeEach {
+        Reset-FixCounter
+    }
+
+    It "Should start at zero after a reset" {
+        Get-FixCount | Should -Be 0
+    }
+
+    It "Should count each applied fix once" {
+        Write-Fix 'first change'  | Out-Null
+        Write-Fix 'second change' | Out-Null
+        Write-Fix 'third change'  | Out-Null
+        Get-FixCount | Should -Be 3
+    }
+
+    It "Should return to zero on a fresh reset" {
+        Write-Fix 'a change' | Out-Null
+        Get-FixCount | Should -Be 1
+        Reset-FixCounter
+        Get-FixCount | Should -Be 0
+    }
+}
+
+Describe "Report log" {
+    # Log appends a timestamped line to the running report, and Get-Report
+    # hands the whole thing back. The report accumulates across the suite, so
+    # these assertions work off the delta rather than an absolute count.
+    It "Should append a timestamped line for each Log call" {
+        $before = (Get-Report).Count
+        Log 'UWSO-UI-TEST-MARKER'
+        $after = Get-Report
+        $after.Count | Should -Be ($before + 1)
+        $after[-1]   | Should -Match 'UWSO-UI-TEST-MARKER'
+    }
+
+    It "Should prefix log entries with an HH:mm:ss stamp" {
+        Log 'stamp check'
+        (Get-Report)[-1] | Should -Match '^\d{2}:\d{2}:\d{2} '
+    }
+}


### PR DESCRIPTION
Two of the modules with no test of their own were also the two that hold the
safety-critical logic, so I started there. This adds 22 tests across two new
files. The full suite goes from 72 to 94, all green, and PSScriptAnalyzer stays
clean.

## Config module (`tests/Config.Tests.ps1`)

- `Test-RegPathAllowed` is the allow-list that keeps `Set-RegValue` from writing
  outside the standard registry hives. Covered both sides: the real hives pass
  (and the match is case-insensitive), while long-form hive names, bare
  filesystem paths, and empty or null input are all rejected.
- `Test-SectionEnabled` drives the `-Only`/`-Skip` filtering. Covered the
  default-on case, each switch on its own, and the precedence rule where `-Only`
  wins when both are passed.
- Shape checks on the constant tables (section list, bloat services, scheduled
  tasks, features): non-empty, no duplicate names, task paths well-formed.
- A round-trip of the dry-run flag and a check that `Get-OptimizerDataDir`
  hands back a directory that actually exists and accepts a write.

## UI module (`tests/UI.Tests.ps1`)

- The fix counter: reset clears it, an applied fix bumps it by one, a second
  reset clears it again. This is the same counter issue #8 was about inflating
  during dry runs, so it is worth a regression guard.
- The report log: `Log` appends one timestamped line per call and `Get-Report`
  returns it. Assertions work off the delta since the report fills up as the
  rest of the suite runs.

## Notes

- These are new files with new names, so they do not collide with the test
  files PR #41 adds.
- Not closing #18 here. That issue asks for coverage across all the optimization
  modules and PR #41 carries the broad version; this just lands real coverage on
  the two safest targets in the meantime.
