### PR TITLE
fix: stop dry runs from counting fixes they never applied (#8)

### DIFF
--- a/modules/Network.psm1
+++ b/modules/Network.psm1
@@ -36,8 +36,11 @@ function Invoke-NetworkOptimization {
         }
     }
 
+    # Issue #8: Set-RegValue stages the write and prints [DRY] under DryRun, so
+    # these [FIX] summaries have to be gated too. The per-key [DRY] lines still
+    # tell the user what would happen; we just don't count it as applied.
     if ($applied -gt 0) {
-        Write-Fix "Nagle's algorithm disabled on $applied physical adapter(s)"
+        if (-not $DryRun) { Write-Fix "Nagle's algorithm disabled on $applied physical adapter(s)" }
     } else {
         Write-Skip "No eligible physical adapters; skipped Nagle tuning"
     }
@@ -48,7 +51,7 @@ function Invoke-NetworkOptimization {
     # guidance is 10-20%. 10 keeps gaming/network priority high without
     # crippling background work.
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile" "SystemResponsiveness" 10
-    Write-Fix "Network throttling disabled (SystemResponsiveness=10)"
+    if (-not $DryRun) { Write-Fix "Network throttling disabled (SystemResponsiveness=10)" }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxCacheTtl" 86400
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters" "MaxNegativeCacheTtl" 5

--- a/modules/Privacy.psm1
+++ b/modules/Privacy.psm1
@@ -6,33 +6,38 @@ function Invoke-PrivacyOptimization {
     $null = $Analysis  # Used for interface consistency
     Write-Host "`n    -- Privacy & Telemetry Hardening --" -ForegroundColor Cyan
 
+    # Issue #8: Set-RegValue already prints a [DRY] line per key when DryRun is
+    # on, so every [FIX] line here has to be gated the same way Explorer does it.
+    # Otherwise a dry run reports fixes it never applied and inflates the counter.
+    $isDry = Get-DryRunMode
+
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\DataCollection" "AllowTelemetry" 0
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\DataCollection" "AllowTelemetry" 0
-    Write-Fix "Telemetry disabled"
+    if (-not $isDry) { Write-Fix "Telemetry disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Search" "AllowCortana" 0
-    Write-Fix "Cortana disabled"
+    if (-not $isDry) { Write-Fix "Cortana disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\AdvertisingInfo" "Enabled" 0
-    Write-Fix "Advertising ID disabled"
+    if (-not $isDry) { Write-Fix "Advertising ID disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "EnableActivityFeed" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "PublishUserActivities" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\System" "UploadUserActivities" 0
-    Write-Fix "Activity History disabled"
+    if (-not $isDry) { Write-Fix "Activity History disabled" }
 
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\LocationAndSensors" "DisableLocation" 1
-    Write-Fix "Location tracking disabled"
+    if (-not $isDry) { Write-Fix "Location tracking disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Siuf\Rules" "NumberOfSIUFInPeriod" 0
     Set-RegValue "HKCU:\Software\Microsoft\Siuf\Rules" "PeriodInNanoSeconds" 0
-    Write-Fix "Feedback requests disabled"
+    if (-not $isDry) { Write-Fix "Feedback requests disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" "Start_TrackProgs" 0
-    Write-Fix "App launch tracking disabled"
+    if (-not $isDry) { Write-Fix "App launch tracking disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Privacy" "TailoredExperiencesWithDiagnosticDataEnabled" 0
-    Write-Fix "Tailored experiences disabled"
+    if (-not $isDry) { Write-Fix "Tailored experiences disabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-338389Enabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-310093Enabled" 0
@@ -40,7 +45,7 @@ function Invoke-PrivacyOptimization {
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SilentInstalledAppsEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SystemPaneSuggestionsEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SoftLandingEnabled" 0
-    Write-Fix "Tips, suggestions, and silent app installs disabled"
+    if (-not $isDry) { Write-Fix "Tips, suggestions, and silent app installs disabled" }
 }
 
 Export-ModuleMember -Function Invoke-PrivacyOptimization

--- a/modules/Security.psm1
+++ b/modules/Security.psm1
@@ -26,18 +26,22 @@ function Invoke-SecurityOptimization {
         } catch { $null = $_ }
     }
 
+    # Issue #8: Set-RegValue prints its own [DRY] line and skips the write when
+    # DryRun is on, so the [FIX] lines that follow a registry change have to be
+    # gated too. Without the guard a dry run counts these as applied fixes. The
+    # firewall block below already does this correctly.
     if ($hasActiveRDP) {
         Write-Warn "Active RDP session detected - skipping Remote Desktop disable"
     } else {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server" "fDenyTSConnections" 1
-        Write-Fix "Remote Desktop disabled (security)"
+        if (-not $DryRun) { Write-Fix "Remote Desktop disabled (security)" }
     }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Remote Assistance" "fAllowToGetHelp" 0
-    Write-Fix "Remote Assistance disabled"
+    if (-not $DryRun) { Write-Fix "Remote Assistance disabled" }
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters" "SMB1" 0
-    Write-Fix "SMBv1 disabled (security)"
+    if (-not $DryRun) { Write-Fix "SMBv1 disabled (security)" }
 
     if ($DryRun) {
         Write-Dry "Would verify Windows Firewall is enabled"
@@ -52,7 +56,7 @@ function Invoke-SecurityOptimization {
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" "NoDriveTypeAutoRun" 255
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\AutoplayHandlers" "DisableAutoplay" 1
-    Write-Fix "AutoRun/AutoPlay disabled (prevents USB malware)"
+    if (-not $DryRun) { Write-Fix "AutoRun/AutoPlay disabled (prevents USB malware)" }
 }
 
 Export-ModuleMember -Function Invoke-SecurityOptimization

--- a/tests/Network.Tests.ps1
+++ b/tests/Network.Tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")          -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "UndoManager.psm1") -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")      -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Network.psm1")     -Force -DisableNameChecking
+}
+
+Describe "Invoke-NetworkOptimization in DryRun" {
+    # Issue #8: the Nagle summary and the throttling line both called Write-Fix
+    # even though every write is staged, not applied, under DryRun. The adapter
+    # and interface reads are mocked so a physical adapter is always "found"
+    # (that path is what fired the bogus Nagle fix) and the run never depends on
+    # the host's real network stack. DNS flush and netsh only run outside DryRun,
+    # so they are never reached here.
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $true
+
+        Mock -ModuleName Network Get-NetAdapter {
+            [pscustomobject]@{
+                InterfaceGuid = '{ABCD1234-5678-90AB-CDEF-1234567890AB}'
+                Status        = 'Up'
+                Virtual       = $false
+            }
+        }
+        Mock -ModuleName Network Get-ChildItem {
+            [pscustomobject]@{
+                PSChildName = '{abcd1234-5678-90ab-cdef-1234567890ab}'
+                PSPath      = 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{abcd1234-5678-90ab-cdef-1234567890ab}'
+            }
+        }
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+        Reset-FixCounter
+    }
+
+    It "Should not increment the fix counter even when an adapter matches" {
+        Invoke-NetworkOptimization -Analysis @{} | Out-Null
+        Get-FixCount | Should -Be 0
+    }
+
+    It "Should run without throwing" {
+        { Invoke-NetworkOptimization -Analysis @{} } | Should -Not -Throw
+    }
+
+    It "Should stage the throttling and Nagle keys" {
+        Invoke-NetworkOptimization -Analysis @{} | Out-Null
+        $joined = (Get-Report) -join "`n"
+        $joined | Should -Match '\[DRY\]  Would set .*SystemResponsiveness'
+        $joined | Should -Match '\[DRY\]  Would set .*TcpNoDelay'
+    }
+}

--- a/tests/Privacy.Tests.ps1
+++ b/tests/Privacy.Tests.ps1
@@ -1,0 +1,38 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")          -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "UndoManager.psm1") -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")      -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Privacy.psm1")     -Force -DisableNameChecking
+}
+
+Describe "Invoke-PrivacyOptimization in DryRun" {
+    # Issue #8: Privacy only writes registry values through Set-RegValue, which
+    # already skips the write and prints a [DRY] line when DryRun is on. The
+    # module must not also fire [FIX] lines, or a dry run claims fixes it never
+    # made and the counter is wrong.
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $true
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+        Reset-FixCounter
+    }
+
+    It "Should not increment the fix counter" {
+        Invoke-PrivacyOptimization -Analysis @{} | Out-Null
+        Get-FixCount | Should -Be 0
+    }
+
+    It "Should run without throwing" {
+        { Invoke-PrivacyOptimization -Analysis @{} } | Should -Not -Throw
+    }
+
+    It "Should still record what it would do in the report log" {
+        Invoke-PrivacyOptimization -Analysis @{} | Out-Null
+        $report = Get-Report
+        ($report -join "`n") | Should -Match '\[DRY\]  Would set .*AllowTelemetry'
+    }
+}

--- a/tests/Security.Tests.ps1
+++ b/tests/Security.Tests.ps1
@@ -1,0 +1,40 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")          -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "UndoManager.psm1") -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")      -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Security.psm1")    -Force -DisableNameChecking
+}
+
+Describe "Invoke-SecurityOptimization in DryRun" {
+    # Issue #8: every registry change routes through Set-RegValue, which stages
+    # the write and prints [DRY] when DryRun is on. The [FIX] lines have to be
+    # gated the same way or a dry run reports fixes it never made. The RDP check
+    # queries Win32_LogonSession, so it is mocked to return no remote session,
+    # which keeps the run identical on any host (CI included).
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $true
+        Mock -ModuleName Security Get-CimInstance { @() }
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+        Reset-FixCounter
+    }
+
+    It "Should not increment the fix counter" {
+        Invoke-SecurityOptimization -Analysis @{} | Out-Null
+        Get-FixCount | Should -Be 0
+    }
+
+    It "Should run without throwing" {
+        { Invoke-SecurityOptimization -Analysis @{} } | Should -Not -Throw
+    }
+
+    It "Should stage the Remote Desktop disable when no RDP session is active" {
+        Invoke-SecurityOptimization -Analysis @{} | Out-Null
+        $report = Get-Report
+        ($report -join "`n") | Should -Match '\[DRY\]  Would set .*fDenyTSConnections'
+    }
+}

--- a/tests/Services.Tests.ps1
+++ b/tests/Services.Tests.ps1
@@ -1,0 +1,72 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")       -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")   -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Services.psm1") -Force -DisableNameChecking
+
+    $script:sampleServices = @(
+        [pscustomobject]@{ Name = 'DiagTrack';   Desc = 'Connected User Experiences and Telemetry' }
+        [pscustomobject]@{ Name = 'dmwappushsvc'; Desc = 'Device Management WAP Push' }
+    )
+}
+
+Describe "Invoke-ServicesOptimization in DryRun" {
+    # The module is already correct here: it prints [DRY] and continues before it
+    # touches a service. This guards that against a regression, so a dry run can
+    # never stop a service or count a fix. Stop-Service and Set-Service are mocked
+    # so a real dry run can never reach the host even if the guard breaks.
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $true
+        Mock -ModuleName Services Stop-Service {}
+        Mock -ModuleName Services Set-Service  {}
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+        Reset-FixCounter
+    }
+
+    It "Should not increment the fix counter" {
+        Invoke-ServicesOptimization -Analysis @{ ServicesToDisable = $script:sampleServices } | Out-Null
+        Get-FixCount | Should -Be 0
+    }
+
+    It "Should not stop or disable any service" {
+        Invoke-ServicesOptimization -Analysis @{ ServicesToDisable = $script:sampleServices } | Out-Null
+        Should -Invoke -ModuleName Services Stop-Service -Times 0
+        Should -Invoke -ModuleName Services Set-Service  -Times 0
+    }
+
+    It "Should record a [DRY] line for each service" {
+        Invoke-ServicesOptimization -Analysis @{ ServicesToDisable = $script:sampleServices } | Out-Null
+        $joined = (Get-Report) -join "`n"
+        $joined | Should -Match '\[DRY\]  Would disable service: .*DiagTrack'
+        $joined | Should -Match '\[DRY\]  Would disable service: .*dmwappushsvc'
+    }
+}
+
+Describe "Invoke-ServicesOptimization outside DryRun" {
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $false
+        Mock -ModuleName Services Stop-Service {}
+        Mock -ModuleName Services Set-Service  {}
+    }
+
+    AfterAll {
+        Reset-FixCounter
+    }
+
+    It "Should count one fix per service actually disabled" {
+        Invoke-ServicesOptimization -Analysis @{ ServicesToDisable = $script:sampleServices } | Out-Null
+        Get-FixCount | Should -Be $script:sampleServices.Count
+        Should -Invoke -ModuleName Services Stop-Service -Times $script:sampleServices.Count
+    }
+
+    It "Should do nothing when the disable list is empty" {
+        Invoke-ServicesOptimization -Analysis @{ ServicesToDisable = @() } | Out-Null
+        Get-FixCount | Should -Be 0
+        Should -Invoke -ModuleName Services Stop-Service -Times 0
+    }
+}


### PR DESCRIPTION
Issue #8 is real: a dry run was reporting fixes it never applied. `Write-Fix`
always bumps the applied-fixes counter, and several modules called it right
after a `Set-RegValue` without checking for dry-run mode. Set-RegValue already
skips the write and prints a `[DRY]` line when dry-run is on, so those `[FIX]`
lines were double-counting work that never happened. Explorer had already been
fixed this way, so I copied its pattern (`if (-not $DryRun)`) across the modules
that still had the problem.

While I was in there, I gave the untouched modules their own test files, since
none of the ones I changed had coverage (issue #18).

What changed:

- **Privacy**: eight `[FIX]` lines were unguarded. Gated all of them.
- **Security**: the Remote Desktop, Remote Assistance, SMBv1, and AutoRun fixes
  were unguarded (the firewall block was already correct). Gated them to match.
- **Network**: the Nagle summary and the throttling line both counted in dry-run.
  When a physical adapter was present, dry-run over-reported by two. Gated both.
- **Services**: already correct, no code change. Added a test so it stays that
  way.
- New tests: `Privacy.Tests.ps1`, `Security.Tests.ps1`, `Services.Tests.ps1`,
  `Network.Tests.ps1`. The Security and Network tests mock their host queries
  (RDP session, network adapters) so they run the same on any machine, and every
  test stays in dry-run so nothing on the host is touched.

Suite goes from 94 to 108 tests, all green. PSScriptAnalyzer is clean.

Follow-ups:

- Performance is the last module named in #8 and still has some unguarded
  `[FIX]` lines, but it does a lot of machine-dependent reads (RAM, volumes,
  power plans), so it needs more mocking than the others. Left it for a separate
  pass rather than rush it here.
- This does not fully close #18. Explorer, Analysis, Cleanup, Config, UI, Undo,
  and the main script still own their coverage; this adds four more files.

Refs #8, #18
