### PR TITLE
Finish issue #8: dry-run handling in the Performance module, with tests

### DIFF
--- a/modules/Performance.psm1
+++ b/modules/Performance.psm1
@@ -53,7 +53,7 @@ function Invoke-PowerOptimization {
         # earlier builds creates a key Windows ignores while we report success.
         if ([int]$Analysis.OSBuild -ge 18362) {
             Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Power\PowerThrottling" "PowerThrottlingOff" 1
-            Write-Fix "Disabled power throttling"
+            if (-not $DryRun) { Write-Fix "Disabled power throttling" }
         } else {
             Write-Skip "Power throttling tweak skipped (requires Windows 10 1903 or newer)"
         }
@@ -65,6 +65,8 @@ function Invoke-PowerOptimization {
 
 function Invoke-VisualEffectsOptimization {
     param([hashtable]$Analysis)
+
+    $DryRun = Get-DryRunMode
 
     Write-Host "`n    -- Visual Effects Optimization --" -ForegroundColor Cyan
 
@@ -81,7 +83,7 @@ function Invoke-VisualEffectsOptimization {
         Set-RegValue $advPath "TaskbarAnimations" 0
         Set-RegValue $dwmPath "EnableAeroPeek" 0
         Set-RegValue "HKCU:\Control Panel\Desktop" "DragFullWindows" "0" "String"
-        Write-Fix "Visual effects set to MAXIMUM PERFORMANCE (Low-End system)"
+        if (-not $DryRun) { Write-Fix "Visual effects set to MAXIMUM PERFORMANCE (Low-End system)" }
     } elseif ($Analysis.SystemTier -eq "Mid-Range") {
         Set-RegValue $vePath "VisualFXSetting" 3
         Set-RegValue "HKCU:\Control Panel\Desktop" "FontSmoothing" "2" "String"
@@ -90,48 +92,50 @@ function Invoke-VisualEffectsOptimization {
         Set-RegValue $advPath "TaskbarAnimations" 0
         Set-RegValue $dwmPath "EnableAeroPeek" 0
         Set-RegValue "HKCU:\Control Panel\Desktop" "DragFullWindows" "1" "String"
-        Write-Fix "Visual effects optimized for balanced quality/performance"
+        if (-not $DryRun) { Write-Fix "Visual effects optimized for balanced quality/performance" }
     } else {
         Set-RegValue "HKCU:\Control Panel\Desktop\WindowMetrics" "MinAnimate" "0" "String"
         Set-RegValue $advPath "TaskbarAnimations" 0
-        Write-Fix "Visual effects: minimal tweaks (High-End system - keeping quality)"
+        if (-not $DryRun) { Write-Fix "Visual effects: minimal tweaks (High-End system - keeping quality)" }
     }
 }
 
 function Invoke-PerformanceOptimization {
     param([hashtable]$Analysis)
 
+    $DryRun = Get-DryRunMode
+
     Write-Host "`n    -- Performance Tweaks --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\GameBar" "AllowAutoGameMode" 1
     Set-RegValue "HKCU:\Software\Microsoft\GameBar" "AutoGameModeEnabled" 1
-    Write-Fix "Game Mode enabled"
+    if (-not $DryRun) { Write-Fix "Game Mode enabled" }
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\GameDVR" "AppCaptureEnabled" 0
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_Enabled" 0
     Set-RegValue "HKLM:\SOFTWARE\Policies\Microsoft\Windows\GameDVR" "AllowGameDVR" 0
-    Write-Fix "Game Bar / DVR capture disabled (reduces overhead)"
+    if (-not $DryRun) { Write-Fix "Game Bar / DVR capture disabled (reduces overhead)" }
 
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_FSEBehaviorMode" 2
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_HonorUserFSEBehaviorMode" 1
     Set-RegValue "HKCU:\System\GameConfigStore" "GameDVR_FSEBehavior" 2
-    Write-Fix "Fullscreen optimizations configured"
+    if (-not $DryRun) { Write-Fix "Fullscreen optimizations configured" }
 
     if ([int]$Analysis.OSBuild -ge 19041) {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\GraphicsDrivers" "HwSchMode" 2
-        Write-Fix "Hardware-accelerated GPU scheduling enabled"
+        if (-not $DryRun) { Write-Fix "Hardware-accelerated GPU scheduling enabled" }
     }
 
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseSpeed" "0" "String"
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseThreshold1" "0" "String"
     Set-RegValue "HKCU:\Control Panel\Mouse" "MouseThreshold2" "0" "String"
-    Write-Fix "Mouse acceleration disabled (1:1 precision)"
+    if (-not $DryRun) { Write-Fix "Mouse acceleration disabled (1:1 precision)" }
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "GPU Priority" 8
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "Priority" 6
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "Scheduling Category" "High" "String"
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Multimedia\SystemProfile\Tasks\Games" "SFIO Priority" "High" "String"
-    Write-Fix "Multimedia scheduler optimized for games"
+    if (-not $DryRun) { Write-Fix "Multimedia scheduler optimized for games" }
 }
 
 function Invoke-SSDOptimization {
@@ -151,7 +155,7 @@ function Invoke-SSDOptimization {
     if ([int]$Analysis.OSBuild -lt 17763) {
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnablePrefetcher" 0
         Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management\PrefetchParameters" "EnableSuperfetch" 0
-        Write-Fix "Prefetch/Superfetch disabled (legacy build, SSD doesn't need it)"
+        if (-not $DryRun) { Write-Fix "Prefetch/Superfetch disabled (legacy build, SSD doesn't need it)" }
     } else {
         Write-Skip "Prefetch/Superfetch left to Windows (1809+ adapts per drive type)"
     }
@@ -208,7 +212,7 @@ function Invoke-MemoryOptimization {
     }
 
     Set-RegValue "HKLM:\SYSTEM\ControlSet001\Services\Ndu" "Start" 4
-    Write-Fix "NDU service disabled (prevents memory leak)"
+    if (-not $DryRun) { Write-Fix "NDU service disabled (prevents memory leak)" }
 }
 
 function Invoke-ScheduledTasksOptimization {
@@ -251,7 +255,7 @@ function Invoke-BootOptimization {
     Write-Host "`n    -- Boot Optimization --" -ForegroundColor Cyan
 
     Set-RegValue "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power" "HiberbootEnabled" 1
-    Write-Fix "Fast Startup enabled"
+    if (-not $DryRun) { Write-Fix "Fast Startup enabled" }
 
     if ($DryRun) {
         Write-Dry "Would reduce boot menu timeout to 3 seconds"
@@ -261,24 +265,26 @@ function Invoke-BootOptimization {
     }
 
     Set-RegValue "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System" "VerboseStatus" 1
-    Write-Fix "Verbose boot messages enabled"
+    if (-not $DryRun) { Write-Fix "Verbose boot messages enabled" }
 }
 
 function Invoke-BackgroundAppsOptimization {
     param([hashtable]$Analysis)
 
     $null = $Analysis  # Used for interface consistency
+    $DryRun = Get-DryRunMode
     Write-Host "`n    -- Background Apps --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications" "GlobalUserDisabled" 1
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Search" "BackgroundAppGlobalToggle" 0
-    Write-Fix "Background apps disabled globally (saves CPU & RAM)"
+    if (-not $DryRun) { Write-Fix "Background apps disabled globally (saves CPU & RAM)" }
 }
 
 function Invoke-NotificationsOptimization {
     param([hashtable]$Analysis)
 
     $null = $Analysis  # Used for interface consistency
+    $DryRun = Get-DryRunMode
     Write-Host "`n    -- Notification & Distraction Cleanup --" -ForegroundColor Cyan
 
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "RotatingLockScreenOverlayEnabled" 0
@@ -286,7 +292,7 @@ function Invoke-NotificationsOptimization {
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\UserProfileEngagement" "ScoobeSystemSettingEnabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" "SubscribedContent-310093Enabled" 0
     Set-RegValue "HKCU:\Software\Microsoft\Windows\CurrentVersion\Notifications\Settings" "NOC_GLOBAL_SETTING_ALLOW_TOASTS_ABOVE_LOCK" 0
-    Write-Fix "Notifications and nag screens reduced"
+    if (-not $DryRun) { Write-Fix "Notifications and nag screens reduced" }
 }
 
 function Invoke-DiskOptimization {

--- a/tests/Performance.Tests.ps1
+++ b/tests/Performance.Tests.ps1
@@ -1,0 +1,87 @@
+BeforeAll {
+    $modulesPath = Join-Path $PSScriptRoot "..\modules"
+    Import-Module (Join-Path $modulesPath "UI.psm1")          -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "UndoManager.psm1") -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Config.psm1")      -Force -DisableNameChecking
+    Import-Module (Join-Path $modulesPath "Performance.psm1") -Force -DisableNameChecking
+
+    # Analysis that steers each function into its registry-writing branch:
+    # a low-end tier for visual effects, a modern build for throttling and
+    # GPU scheduling, an SSD present, and enough RAM for the memory path.
+    $script:Analysis = @{
+        IsLaptop   = $false
+        OSBuild    = 22631
+        SystemTier = 'Low-End'
+        HasSSD     = $true
+        HasHDD     = $false
+        TotalRAMGB = 16
+    }
+}
+
+Describe "Performance module honors DryRun (issue #8)" {
+    # The eight functions that write registry values through Set-RegValue.
+    # Set-RegValue already stages the write and prints a [DRY] line when
+    # DryRun is on, so none of these should also fire a [FIX] line or the
+    # applied-fixes counter ends up higher than the work actually done.
+    $dryCases = @(
+        @{ Name = 'Invoke-PowerOptimization' }
+        @{ Name = 'Invoke-VisualEffectsOptimization' }
+        @{ Name = 'Invoke-PerformanceOptimization' }
+        @{ Name = 'Invoke-SSDOptimization' }
+        @{ Name = 'Invoke-MemoryOptimization' }
+        @{ Name = 'Invoke-BootOptimization' }
+        @{ Name = 'Invoke-BackgroundAppsOptimization' }
+        @{ Name = 'Invoke-NotificationsOptimization' }
+    )
+
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $true
+    }
+
+    AfterAll {
+        Set-DryRunMode $false
+        Reset-FixCounter
+    }
+
+    It "<Name> leaves the fix counter at zero in dry run" -ForEach $dryCases {
+        & $Name -Analysis $script:Analysis | Out-Null
+        Get-FixCount | Should -Be 0
+    }
+
+    It "<Name> runs without throwing in dry run" -ForEach $dryCases {
+        { & $Name -Analysis $script:Analysis } | Should -Not -Throw
+    }
+
+    It "still records the staged writes in the report log" {
+        Invoke-BackgroundAppsOptimization -Analysis $script:Analysis | Out-Null
+        $report = Get-Report
+        ($report -join "`n") | Should -Match '\[DRY\]  Would set .*GlobalUserDisabled'
+    }
+}
+
+Describe "Performance module still counts fixes in a real run" {
+    # The dry-run guard must not suppress [FIX] when DryRun is off. Set-RegValue
+    # is mocked here so the assertion stays on the counter and never touches the
+    # real registry. Only functions whose counting path is Set-RegValue plus
+    # Write-Fix are used, so no powercfg/fsutil/bcdedit call is involved.
+    BeforeEach {
+        Reset-FixCounter
+        Set-DryRunMode $false
+        Mock -ModuleName Performance Set-RegValue { $true }
+    }
+
+    AfterAll {
+        Reset-FixCounter
+    }
+
+    It "Invoke-BackgroundAppsOptimization counts its fix when applied for real" {
+        Invoke-BackgroundAppsOptimization -Analysis $script:Analysis | Out-Null
+        Get-FixCount | Should -Be 1
+    }
+
+    It "Invoke-NotificationsOptimization counts its fix when applied for real" {
+        Invoke-NotificationsOptimization -Analysis $script:Analysis | Out-Null
+        Get-FixCount | Should -Be 1
+    }
+}


### PR DESCRIPTION
Wraps up issue #8. The other modules already hold back their `[FIX]` output
during a dry run, but Performance never got that guard, so a dry run there
still counted registry tweaks as applied and pushed the fix counter too
high. This was the last module still doing it.

## What changed
- Gated every `[FIX]` line in `Performance.psm1` that reports a registry
  write behind the dry-run flag, across all eight functions that touch the
  registry (power plan, visual effects, performance tweaks, SSD, memory,
  boot, background apps, notifications). The powercfg, fsutil, and bcdedit
  branches were already inside their own dry-run guards, so those are left
  alone, and a real run counts exactly as it did before.
- Added `tests/Performance.Tests.ps1`. This was the largest module with no
  test file of its own, which is how the gap went unnoticed. Each of the
  eight functions runs in dry mode and gets checked for a zero fix counter
  while the staged `[DRY]` writes still show up in the report log. There is
  also a real-run check with `Set-RegValue` mocked out, so the guard can
  only ever suppress the count when dry-run is on, never when the change
  actually lands.

## Checks
- PSScriptAnalyzer clean on all scripts
- Pester suite green, 108 to 127 tests

## Follow-up (not here)
- #14 (context menu restore skipping the undo system) needs more than
  routing the write through `Set-RegValue`. Removing just the empty
  `InprocServer32` default value leaves the key behind and does not fully
  bring back the Windows 11 menu, so a real fix needs the undo system to
  delete the whole CLSID key. That belongs in its own change.

Closes #8
